### PR TITLE
Add form editor and centralized model service

### DIFF
--- a/applications/electron-app/package.json
+++ b/applications/electron-app/package.json
@@ -31,6 +31,7 @@
     "@crossbreeze/core": "0.0.0",
     "@crossbreeze/glsp-client": "0.0.0",
     "@crossbreeze/product": "0.0.0",
+    "@crossbreeze/form-client": "0.0.0",
     "@theia/core": "^1.34.1",
     "@theia/editor": "^1.34.1",
     "@theia/electron": "^1.34.1",

--- a/extensions/crossmodel-lang/package.json
+++ b/extensions/crossmodel-lang/package.json
@@ -80,6 +80,8 @@
     "langium": "~1.0.0",
     "vscode-languageclient": "^8.0.2",
     "vscode-languageserver": "^8.0.2",
+    "vscode-languageserver-protocol": "^3.17.3",
+    "vscode-languageserver-textdocument": "^1.0.8",
     "vscode-uri": "^3.0.2"
   },
   "devDependencies": {

--- a/extensions/crossmodel-lang/src/glsp-server/model/cross-model-storage.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/model/cross-model-storage.ts
@@ -36,7 +36,7 @@ export class CrossModelStorage implements SourceModelStorage {
          // let's check if there is an existing diagram or we will create one on the fly
          const diagramPath = document.uri.fsPath.split('.').slice(0, -1).join('.') + '.diagram.cm';
          const diagramUri = URI.file(diagramPath);
-         const diagramString = this.state.services.language.serializer.CrossModelSerializer.asDiagram(root);
+         const diagramString = this.state.services.language.serializer.Serializer.asDiagram(root);
          diagramDocument = this.state.services.shared.workspace.LangiumDocumentFactory.fromString(diagramString, diagramUri);
          // do we need to call the builder? it indexes the file but also does linking and scope computation
          // probably no risk as diagrams are self-contained and do not export any objects anyway
@@ -58,7 +58,7 @@ export class CrossModelStorage implements SourceModelStorage {
    }
 
    protected saveDocument(root: AstNode, uri: URI = root.$document!.uri): void {
-      const newContent = this.state.services.language.serializer.CrossModelSerializer.serialize(this.state.semanticRoot);
+      const newContent = this.state.services.language.serializer.Serializer.serialize(this.state.semanticRoot);
 
       // probably need to extend file service from LSP to support writing
       // this.state.services.shared.workspace.FileSystemProvider

--- a/extensions/crossmodel-lang/src/main.ts
+++ b/extensions/crossmodel-lang/src/main.ts
@@ -8,6 +8,7 @@ import { NodeFileSystem } from 'langium/node';
 import { createConnection, ProposedFeatures } from 'vscode-languageserver/node';
 import { startGLSPServer } from './glsp-server/launch';
 import { createCrossModelServices } from './language-server/cross-model-module';
+import { startJsonServer } from './model-server/launch';
 
 // Create a connection to the client
 const connection = createConnection(ProposedFeatures.all);
@@ -21,4 +22,6 @@ startLanguageServer(shared);
 shared.workspace.WorkspaceManager.onWorkspaceInitialized(() => {
    // Start the graphical language server with the shared services
    startGLSPServer({ shared, language: CrossModel });
+   // Start the JSON server with the shared services
+   startJsonServer({ shared, language: CrossModel });
 });

--- a/extensions/crossmodel-lang/src/model-server/launch.ts
+++ b/extensions/crossmodel-lang/src/model-server/launch.ts
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+import * as net from 'net';
+import * as rpc from 'vscode-jsonrpc/node';
+import { CrossModelLSPServices } from '../glsp-server/integration';
+import { ModelServer } from './model-server';
+
+const JSON_SERVER_PORT = 5999;
+const JSON_SERVER_HOST = 'localhost';
+
+const currentConnections: rpc.MessageConnection[] = [];
+
+export function startJsonServer(services?: CrossModelLSPServices): Promise<void> {
+   const netServer = net.createServer(socket => createClientConnection(socket, services));
+   netServer.listen(JSON_SERVER_PORT, JSON_SERVER_HOST);
+   netServer.on('listening', () => {
+      const addressInfo = netServer.address();
+      if (!addressInfo) {
+         console.error('Could not resolve JSON Server address info. Shutting down.');
+         close(netServer);
+         return;
+      } else if (typeof addressInfo === 'string') {
+         console.error(`JSON Server is unexpectedly listening to pipe or domain socket "${addressInfo}". Shutting down.`);
+         close(netServer);
+         return;
+      }
+      console.log(`The JSON server is ready to accept new client requests on port: ${addressInfo.port}`);
+   });
+   netServer.on('error', err => {
+      console.error('JSON server experienced error', err);
+      close(netServer);
+   });
+   return new Promise((resolve, reject) => {
+      netServer.on('close', () => resolve(undefined));
+      netServer.on('error', error => reject(error));
+   });
+}
+
+async function createClientConnection(socket: net.Socket, services?: CrossModelLSPServices): Promise<void> {
+   console.info(`Starting model server connection for client: '${socket.localAddress}'`);
+   const connection = createConnection(socket);
+   connection.listen();
+   currentConnections.push(connection);
+
+   if (!services) {
+      throw new Error('Cannot start model server without Langium services');
+   }
+
+   const modelServer = new ModelServer(connection, services.language.model.ModelService);
+   connection.onDispose(() => modelServer.dispose());
+   socket.on('close', () => modelServer.dispose());
+
+   return new Promise((resolve, rejects) => {
+      connection.onClose(() => resolve(undefined));
+      connection.onError(error => rejects(error));
+   });
+}
+
+function createConnection(socket: net.Socket): rpc.MessageConnection {
+   return rpc.createMessageConnection(new rpc.SocketMessageReader(socket), new rpc.SocketMessageWriter(socket), console);
+}
+
+function close(netServer: net.Server): void {
+   currentConnections.forEach(connection => connection.dispose());
+   netServer.close();
+}

--- a/extensions/crossmodel-lang/src/model-server/model-module.ts
+++ b/extensions/crossmodel-lang/src/model-server/model-module.ts
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { AstNode } from 'langium';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { ModelService } from './model-service';
+import { OpenTextDocumentManager } from './open-text-document-manager';
+import { OpenableTextDocuments } from './openable-text-documents';
+import { Serializer } from './serializer';
+
+export interface AddedSharedModelServices {
+   workspace: {
+      /* override */ TextDocuments: OpenableTextDocuments<TextDocument>;
+      TextDocumentManager: OpenTextDocumentManager;
+   };
+}
+
+export interface ModelServices {
+   serializer: {
+      Serializer: Serializer<AstNode>;
+   };
+   model: {
+      ModelService: ModelService;
+   };
+}
+
+export interface ModelLSPServices {
+   shared: AddedSharedModelServices;
+   language: ModelServices;
+}

--- a/extensions/crossmodel-lang/src/model-server/model-server.ts
+++ b/extensions/crossmodel-lang/src/model-server/model-server.ts
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { AstNode } from 'langium';
+import { Disposable } from 'vscode-jsonrpc';
+import * as rpc from 'vscode-jsonrpc/node';
+import { ModelService } from './model-service';
+
+const OpenModel = new rpc.RequestType1<string, void, void>('server/open');
+const CloseModel = new rpc.RequestType1<string, void, void>('server/close');
+const RequestModel = new rpc.RequestType1<string, AstNode | undefined, void>('server/request');
+const UpdateModel = new rpc.RequestType2<string, AstNode, void, void>('server/update');
+const SaveModel = new rpc.RequestType2<string, AstNode, void, void>('server/save');
+
+export class ModelServer implements Disposable {
+   protected toDispose: Disposable[] = [];
+
+   constructor(protected connection: rpc.MessageConnection, protected modelService: ModelService) {
+      this.initialize(connection);
+   }
+
+   protected initialize(connection: rpc.MessageConnection): void {
+      this.toDispose.push(connection.onRequest(OpenModel, uri => this.modelService.open(uri)));
+      this.toDispose.push(connection.onRequest(CloseModel, uri => this.modelService.close(uri)));
+      this.toDispose.push(connection.onRequest(RequestModel, uri => this.modelService.request(uri)));
+      this.toDispose.push(connection.onRequest(UpdateModel, (uri, model) => this.modelService.update(uri, model)));
+      this.toDispose.push(connection.onRequest(SaveModel, (uri, model) => this.modelService.save(uri, model)));
+   }
+
+   dispose(): void {
+      this.toDispose.forEach(disposable => disposable.dispose());
+   }
+}

--- a/extensions/crossmodel-lang/src/model-server/model-service.ts
+++ b/extensions/crossmodel-lang/src/model-server/model-service.ts
@@ -1,0 +1,81 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { AstNode, DocumentBuilder, isAstNode, isReference, LangiumDefaultSharedServices, LangiumDocuments } from 'langium';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+import { AddedSharedModelServices, ModelServices } from './model-module';
+import { OpenTextDocumentManager } from './open-text-document-manager';
+import { Serializer } from './serializer';
+
+export class ModelService {
+   protected serializer: Serializer<AstNode>;
+   protected documentManager: OpenTextDocumentManager;
+   protected documents: LangiumDocuments;
+   protected documentBuilder: DocumentBuilder;
+
+   constructor(modelServices: ModelServices, shared: AddedSharedModelServices & LangiumDefaultSharedServices) {
+      this.serializer = modelServices.serializer.Serializer;
+      this.documentManager = shared.workspace.TextDocumentManager;
+      this.documents = shared.workspace.LangiumDocuments;
+      this.documentBuilder = shared.workspace.DocumentBuilder;
+   }
+
+   async open(uri: string): Promise<void> {
+      await this.documentManager.open(uri);
+   }
+
+   async close(uri: string): Promise<void> {
+      await this.documentManager.close(uri);
+   }
+
+   async request(uri: string): Promise<AstNode | undefined> {
+      await this.open(uri);
+      const document = this.documents.getOrCreateDocument(URI.parse(uri));
+      const root = document.parseResult.value;
+      return isAstNode(root) ? cleanLangiumElement(root) : undefined;
+   }
+
+   async update(uri: string, model: AstNode): Promise<void> {
+      await this.open(uri);
+      const document = this.documents.getOrCreateDocument(URI.parse(uri));
+      const root = document.parseResult.value;
+      if (!isAstNode(root)) {
+         throw new Error(`No AST node to update exists in '${uri}'`);
+      }
+
+      const text = this.serializer.serialize(model);
+      const version = document.textDocument.version + 1;
+
+      TextDocument.update(document.textDocument, [{ text }], version);
+      await this.documentManager.update(uri, version, text);
+      await this.documentBuilder.update([URI.parse(uri)], []);
+   }
+
+   async save(uri: string, model: AstNode): Promise<void> {
+      const text = this.serializer.serialize(model);
+      await this.documentManager.save(uri, text);
+   }
+}
+
+export function cleanLangiumElement<T extends object>(obj: T): T {
+   return <T>Object.entries(obj)
+      .filter(([key, value]) => !key.startsWith('$') || key === '$type')
+      .reduce((acc, [key, value]) => ({ ...acc, [key]: cleanValue(value) }), {});
+}
+
+function cleanValue(value: any): any {
+   return isContainedObject(value) ? cleanLangiumElement(value) : resolvedValue(value);
+}
+
+function isContainedObject(value: any): boolean {
+   return value === Object(value) && !isReference(value);
+}
+
+function resolvedValue(value: any): any {
+   if (isReference(value)) {
+      return value.$refText;
+   }
+   return value;
+}

--- a/extensions/crossmodel-lang/src/model-server/open-text-document-manager.ts
+++ b/extensions/crossmodel-lang/src/model-server/open-text-document-manager.ts
@@ -1,0 +1,77 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import * as fs from 'fs';
+import { FileSystemProvider, LangiumDefaultSharedServices } from 'langium';
+import { TextDocumentIdentifier, TextDocumentItem, VersionedTextDocumentIdentifier } from 'vscode-languageserver-protocol';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { URI } from 'vscode-uri';
+import { AddedSharedModelServices } from './model-module';
+import { OpenableTextDocuments } from './openable-text-documents';
+
+export class OpenTextDocumentManager {
+   protected textDocuments: OpenableTextDocuments<TextDocument>;
+   protected fileSystemProvider: FileSystemProvider;
+   protected languageId: string;
+
+   protected openDocuments: string[] = [];
+
+   constructor(services: AddedSharedModelServices & LangiumDefaultSharedServices) {
+      this.textDocuments = services.workspace.TextDocuments;
+      this.fileSystemProvider = services.workspace.FileSystemProvider;
+      this.textDocuments.onDidOpen(event => this.open(event.document.uri, event.document.languageId));
+      this.textDocuments.onDidClose(event => this.close(event.document.uri));
+   }
+
+   async open(uri: string, languageId?: string): Promise<void> {
+      if (this.isOpen(uri)) {
+         return;
+      }
+      this.openDocuments.push(this.normalizedUri(uri));
+      const textDocument = await this.readFromFilesystem(uri, languageId ?? this.languageId);
+      this.textDocuments.notifyDidOpenTextDocument({ textDocument });
+   }
+
+   async close(uri: string): Promise<void> {
+      if (!this.isOpen(uri)) {
+         return;
+      }
+      this.removeFromOpenedDocuments(uri);
+      this.textDocuments.notifyDidCloseTextDocument({ textDocument: TextDocumentIdentifier.create(uri) });
+   }
+
+   async update(uri: string, version: number, text: string): Promise<void> {
+      if (!this.isOpen(uri)) {
+         throw new Error(`Document ${uri} hasn't been opened for updating yet`);
+      }
+      this.textDocuments.notifyDidChangeTextDocument({
+         textDocument: VersionedTextDocumentIdentifier.create(uri, version),
+         contentChanges: [{ text }]
+      });
+   }
+
+   async save(uri: string, text: string): Promise<void> {
+      const vscUri = URI.parse(uri);
+      fs.writeFileSync(vscUri.fsPath, text);
+      this.textDocuments.notifyDidSaveTextDocument({ textDocument: TextDocumentIdentifier.create(uri) });
+   }
+
+   protected isOpen(uri: string): boolean {
+      return this.openDocuments.includes(this.normalizedUri(uri));
+   }
+
+   protected removeFromOpenedDocuments(uri: string): void {
+      this.openDocuments.splice(this.openDocuments.indexOf(this.normalizedUri(uri)));
+   }
+
+   protected async readFromFilesystem(uri: string, languageId?: string): Promise<TextDocumentItem> {
+      const vscUri = URI.parse(uri);
+      const content = this.fileSystemProvider.readFileSync(vscUri);
+      return TextDocumentItem.create(vscUri.toString(), languageId ?? this.languageId, 1, content.toString());
+   }
+
+   protected normalizedUri(uri: string): string {
+      return URI.parse(uri).toString();
+   }
+}

--- a/extensions/crossmodel-lang/src/model-server/openable-text-documents.ts
+++ b/extensions/crossmodel-lang/src/model-server/openable-text-documents.ts
@@ -1,0 +1,168 @@
+/* eslint-disable header/header */
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation and EclipseSource. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import {
+   CancellationToken,
+   DidChangeTextDocumentParams,
+   DidCloseTextDocumentParams,
+   DidOpenTextDocumentParams,
+   DidSaveTextDocumentParams,
+   Disposable,
+   DocumentUri,
+   Emitter,
+   HandlerResult,
+   RequestHandler,
+   TextDocumentChangeEvent,
+   TextDocuments,
+   TextDocumentsConfiguration,
+   TextDocumentSyncKind,
+   TextDocumentWillSaveEvent,
+   TextEdit,
+   WillSaveTextDocumentParams
+} from 'vscode-languageserver';
+
+/**
+ * This subclass of `TextDocuments` is actually entirely equivalent to `TextDocuments` but opens up
+ * methods to be able to invoke events from within the language server (see json-server.ts).
+ *
+ * Otherwise the document will be read all the time from the disk
+ * langium/src/workspace/documents.ts:222 which relies on _syncedDocuments to be open
+ * vscode-languageserver/lib/common/textDocuments.js:119
+ */
+export class OpenableTextDocuments<T extends { uri: DocumentUri }> extends TextDocuments<T> {
+   public constructor(protected configuration: TextDocumentsConfiguration<T>) {
+      super(configuration);
+   }
+
+   protected get __syncedDocuments(): Map<string, T> {
+      return this['_syncedDocuments'];
+   }
+
+   protected get __onDidChangeContent(): Emitter<TextDocumentChangeEvent<T>> {
+      return this['_onDidChangeContent'];
+   }
+
+   protected get __onDidOpen(): Emitter<TextDocumentChangeEvent<T>> {
+      return this['_onDidOpen'];
+   }
+
+   protected get __onDidClose(): Emitter<TextDocumentChangeEvent<T>> {
+      return this['_onDidClose'];
+   }
+
+   protected get __onDidSave(): Emitter<TextDocumentChangeEvent<T>> {
+      return this['_onDidSave'];
+   }
+
+   protected get __onWillSave(): Emitter<TextDocumentWillSaveEvent<T>> {
+      return this['_onWillSave'];
+   }
+
+   protected get __willSaveWaitUntil(): RequestHandler<TextDocumentWillSaveEvent<T>, TextEdit[], void> | undefined {
+      return this['_willSaveWaitUntil'];
+   }
+
+   public override listen(connection: any): Disposable {
+      (<any>connection).__textDocumentSync = TextDocumentSyncKind.Incremental;
+      const disposables: Disposable[] = [];
+      disposables.push(
+         connection.onDidOpenTextDocument((event: DidOpenTextDocumentParams) => {
+            this.notifyDidOpenTextDocument(event);
+         })
+      );
+      disposables.push(
+         connection.onDidChangeTextDocument((event: DidChangeTextDocumentParams) => {
+            this.notifyDidChangeTextDocument(event);
+         })
+      );
+      disposables.push(
+         connection.onDidCloseTextDocument((event: DidCloseTextDocumentParams) => {
+            this.notifyDidCloseTextDocument(event);
+         })
+      );
+      disposables.push(
+         connection.onWillSaveTextDocument((event: WillSaveTextDocumentParams) => {
+            this.notifyWillSaveTextDocument(event);
+         })
+      );
+      disposables.push(
+         connection.onWillSaveTextDocumentWaitUntil((event: WillSaveTextDocumentParams, token: CancellationToken) =>
+            this.notifyWillSaveTextDocumentWaitUntil(event, token)
+         )
+      );
+      disposables.push(
+         connection.onDidSaveTextDocument((event: DidSaveTextDocumentParams) => {
+            this.notifyDidSaveTextDocument(event);
+         })
+      );
+      return Disposable.create(() => {
+         disposables.forEach(disposable => disposable.dispose());
+      });
+   }
+
+   public notifyDidChangeTextDocument(event: DidChangeTextDocumentParams): void {
+      const td = event.textDocument;
+      const changes = event.contentChanges;
+      if (changes.length === 0) {
+         return;
+      }
+
+      const { version } = td;
+      // eslint-disable-next-line no-null/no-null
+      if (version === null || version === undefined) {
+         throw new Error(`Received document change event for ${td.uri} without valid version identifier`);
+      }
+
+      let syncedDocument = this.__syncedDocuments.get(td.uri);
+      if (syncedDocument !== undefined) {
+         syncedDocument = this.configuration.update(syncedDocument, changes, version);
+         this.__syncedDocuments.set(td.uri, syncedDocument);
+         this.__onDidChangeContent.fire(Object.freeze({ document: syncedDocument }));
+      }
+   }
+
+   public notifyDidCloseTextDocument(event: DidCloseTextDocumentParams): void {
+      const syncedDocument = this.__syncedDocuments.get(event.textDocument.uri);
+      if (syncedDocument !== undefined) {
+         this.__syncedDocuments.delete(event.textDocument.uri);
+         this.__onDidClose.fire(Object.freeze({ document: syncedDocument }));
+      }
+   }
+
+   public notifyWillSaveTextDocument(event: WillSaveTextDocumentParams): void {
+      const syncedDocument = this.__syncedDocuments.get(event.textDocument.uri);
+      if (syncedDocument !== undefined) {
+         this.__onWillSave.fire(Object.freeze({ document: syncedDocument, reason: event.reason }));
+      }
+   }
+
+   public notifyWillSaveTextDocumentWaitUntil(
+      event: WillSaveTextDocumentParams,
+      token: CancellationToken
+   ): HandlerResult<TextEdit[], void> {
+      const syncedDocument = this.__syncedDocuments.get(event.textDocument.uri);
+      if (syncedDocument !== undefined && this.__willSaveWaitUntil) {
+         return this.__willSaveWaitUntil(Object.freeze({ document: syncedDocument, reason: event.reason }), token);
+      } else {
+         return [];
+      }
+   }
+
+   public notifyDidSaveTextDocument(event: DidSaveTextDocumentParams): void {
+      const syncedDocument = this.__syncedDocuments.get(event.textDocument.uri);
+      if (syncedDocument !== undefined) {
+         this.__onDidSave.fire(Object.freeze({ document: syncedDocument }));
+      }
+   }
+
+   public notifyDidOpenTextDocument(event: DidOpenTextDocumentParams): void {
+      const td = event.textDocument;
+      const document = this.configuration.create(td.uri, td.languageId, td.version, td.text);
+      this.__syncedDocuments.set(td.uri, document);
+      const toFire = Object.freeze({ document });
+      this.__onDidOpen.fire(toFire);
+      this.__onDidChangeContent.fire(toFire);
+   }
+}

--- a/extensions/crossmodel-lang/src/model-server/serializer.ts
+++ b/extensions/crossmodel-lang/src/model-server/serializer.ts
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { AstNode } from 'langium';
+
+export interface Serializer<T extends AstNode> {
+   serialize(model: T): string;
+}
+
+export interface DiagramSerializer<T extends AstNode> extends Serializer<T> {
+   asDiagram(model: T): string;
+}

--- a/packages/form-client/package.json
+++ b/packages/form-client/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@crossbreeze/form-client",
+  "version": "0.0.0",
+  "private": true,
+  "description": "CrossModel Form-based Editor Contribution",
+  "keywords": [
+    "theia-extension"
+  ],
+  "homepage": "https://github.com/CrossBreezeNL/CrossModel",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CrossBreezeNL/CrossModel"
+  },
+  "license": "UNLICENSED",
+  "author": {
+    "name": "CrossBreeze Team",
+    "email": "team@x-breeze.com"
+  },
+  "files": [
+    "lib",
+    "src",
+    "style"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
+    "lint": "eslint -c ../../.eslintrc.js --ext .ts,.tsx ./src",
+    "prepare": "yarn clean && yarn build",
+    "watch": "tsc -w"
+  },
+  "dependencies": {
+    "@crossbreeze/core": "0.0.0",
+    "@theia/core": "^1.34.0",
+    "vscode-jsonrpc": "^8.0.2"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/form-client-frontend-module",
+      "backend": "lib/node/form-client-backend-module"
+    }
+  ]
+}

--- a/packages/form-client/src/browser/form-client-frontend-module.ts
+++ b/packages/form-client/src/browser/form-client-frontend-module.ts
@@ -1,0 +1,35 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { URI } from '@theia/core';
+import { NavigatableWidgetOptions, OpenHandler, WebSocketConnectionProvider, WidgetFactory } from '@theia/core/lib/browser';
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { FormEditorClient, FormEditorService, FORM_EDITOR_SERVICE_PATH } from '../common/form-client-protocol';
+import { FormEditorClientImpl } from './form-client';
+import { createFormEditorId, FormEditorOpenHandler } from './form-editor-open-handler';
+import { FormEditorWidget, FormEditorWidgetOptions } from './form-editor-widget';
+
+export default new ContainerModule(bind => {
+   bind(FormEditorClient).to(FormEditorClientImpl).inSingletonScope();
+   bind(FormEditorService)
+      .toDynamicValue(ctx => {
+         const connection = ctx.container.get(WebSocketConnectionProvider);
+         const backendClient: FormEditorClient = ctx.container.get(FormEditorClient);
+         return connection.createProxy<FormEditorService>(FORM_EDITOR_SERVICE_PATH, backendClient);
+      })
+      .inSingletonScope();
+
+   bind(OpenHandler).to(FormEditorOpenHandler).inSingletonScope();
+   bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({
+      id: FormEditorOpenHandler.ID,
+      createWidget: (options: NavigatableWidgetOptions) => {
+         const container = context.container.createChild();
+         const uri = new URI(options.uri);
+         const id = createFormEditorId(uri, options.counter);
+         container.bind(FormEditorWidgetOptions).toConstantValue({ ...options, id });
+         container.bind(FormEditorWidget).toSelf();
+         return container.get(FormEditorWidget);
+      }
+   }));
+});

--- a/packages/form-client/src/browser/form-client.ts
+++ b/packages/form-client/src/browser/form-client.ts
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { injectable } from '@theia/core/shared/inversify';
+import { FormEditorClient } from '../common/form-client-protocol';
+
+@injectable()
+export class FormEditorClientImpl implements FormEditorClient {
+   getName(): Promise<string> {
+      return new Promise(resolve => resolve('Client'));
+   }
+}

--- a/packages/form-client/src/browser/form-editor-open-handler.ts
+++ b/packages/form-client/src/browser/form-editor-open-handler.ts
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { MaybePromise, nls } from '@theia/core';
+import { NavigatableWidgetOpenHandler, WidgetOpenerOptions } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { injectable } from '@theia/core/shared/inversify';
+import { FormEditorWidget } from './form-editor-widget';
+
+@injectable()
+export class FormEditorOpenHandler extends NavigatableWidgetOpenHandler<FormEditorWidget> {
+   static ID = 'form-editor-opener';
+
+   readonly id = FormEditorOpenHandler.ID;
+   readonly label = nls.localize('form-client/form-editor', 'Form Editor');
+
+   canHandle(uri: URI, options?: WidgetOpenerOptions): MaybePromise<number> {
+      return uri.path.ext === '.cm' ? 1 : -1;
+   }
+}
+
+export function createFormEditorId(uri: URI, counter?: number): string {
+   return FormEditorOpenHandler.ID + `:${uri.toString()}` + (counter !== undefined ? `:${counter}` : '');
+}

--- a/packages/form-client/src/browser/form-editor-widget.tsx
+++ b/packages/form-client/src/browser/form-editor-widget.tsx
@@ -1,0 +1,181 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { CommandService, Emitter, Event } from '@theia/core';
+import { LabelProvider, NavigatableWidget, NavigatableWidgetOptions, ReactWidget, Saveable, SaveOptions } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import * as React from '@theia/core/shared/react';
+import { CrossModelRoot, Entity, FormEditorService, Relationship } from '../common/form-client-protocol';
+
+export const FormEditorWidgetOptions = Symbol('FormEditorWidgetOptions');
+export interface FormEditorWidgetOptions extends NavigatableWidgetOptions {
+   id: string;
+}
+
+export interface ProjectSettings {
+   hardware: string;
+   serialPrinting: string;
+   name?: string;
+   url?: string;
+}
+
+@injectable()
+export class FormEditorWidget extends ReactWidget implements NavigatableWidget, Saveable {
+   dirty = false;
+   autoSave: 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange';
+   public readonly onDirtyChangedEmitter = new Emitter<void>();
+   onDirtyChanged: Event<void> = this.onDirtyChangedEmitter.event;
+
+   @inject(FormEditorWidgetOptions) protected options: FormEditorWidgetOptions;
+   @inject(LabelProvider) protected labelProvider: LabelProvider;
+   @inject(FormEditorService) private readonly formEditorService: FormEditorService;
+   @inject(CommandService) protected commandService: CommandService;
+
+   protected model: CrossModelRoot | undefined = undefined;
+   protected error: string | undefined = undefined;
+
+   @postConstruct()
+   init(): void {
+      this.id = this.options.id;
+      this.title.label = this.labelProvider.getName(this.getResourceUri());
+      this.title.iconClass = this.labelProvider.getIcon(this.getResourceUri());
+      this.title.closable = true;
+      this.loadModel();
+   }
+
+   protected async loadModel(): Promise<void> {
+      try {
+         const uri = this.getResourceUri().toString();
+         await this.formEditorService.open(uri);
+         const model = await this.formEditorService.request(uri);
+         if (model) {
+            this.model = model;
+         }
+      } catch (error: any) {
+         this.error = error;
+      } finally {
+         this.update();
+      }
+   }
+
+   override close(): void {
+      this.formEditorService.close(this.getResourceUri().toString());
+      super.close();
+   }
+
+   render(): React.ReactNode {
+      if (!this.model && this.error === undefined) {
+         return <div className='form-editor loading'></div>;
+      }
+      if (!this.model && this.error !== undefined) {
+         return (
+            <div className='form-editor error'>
+               <p>{this.error}</p>
+            </div>
+         );
+      }
+
+      if (this.model?.entity) {
+         return this.renderEntity(this.model.entity);
+      } else if (this.model?.relationship) {
+         return this.renderRelationship(this.model.relationship);
+      } else {
+         return (
+            <div className='form-editor error'>
+               <p>Unknown model element</p>
+            </div>
+         );
+      }
+   }
+
+   renderRelationship(relationship: Relationship): React.ReactNode {
+      return (
+         <div className='form-editor'>
+            <div className='header'>
+               <h1>
+                  <span className='label'>Relationship&nbsp;</span>
+                  <span className='value'>{relationship.name}</span>
+               </h1>
+            </div>
+            <div>
+               Source:
+               <input
+                  className='theia-input'
+                  value={relationship.source}
+                  onChange={e => {
+                     relationship.source = e.target.value;
+                     this.updateModel(e);
+                  }}
+               />
+            </div>
+            <div>
+               Target:
+               <input
+                  className='theia-input'
+                  value={relationship.target}
+                  onChange={e => {
+                     relationship.target = e.target.value;
+                     this.updateModel(e);
+                  }}
+               />
+            </div>
+         </div>
+      );
+   }
+
+   renderEntity(entity: Entity): React.ReactNode {
+      return (
+         <div className='form-editor'>
+            <div className='header'>
+               <h1>
+                  <span className='label'>Entity&nbsp;</span>
+                  <span className='value'>{entity.name}</span>
+               </h1>
+            </div>
+            <div>
+               Description:
+               <input
+                  className='theia-input'
+                  value={entity.description}
+                  onChange={e => {
+                     entity.description = e.target.value;
+                     this.updateModel(e);
+                  }}
+               />
+            </div>
+         </div>
+      );
+   }
+
+   getResourceUri(): URI {
+      return new URI(this.options.uri);
+   }
+
+   createMoveToUri(resourceUri: URI): URI | undefined {
+      return undefined;
+   }
+
+   protected async updateModel(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
+      this.setDirty(true);
+      this.update();
+      await this.formEditorService.update(this.getResourceUri().toString(), this.model!);
+   }
+
+   async save(options?: SaveOptions | undefined): Promise<void> {
+      if (this.model === undefined) {
+         throw new Error('Cannot save undefined model');
+      }
+      await this.formEditorService.save(this.getResourceUri().toString(), this.model);
+      this.setDirty(false);
+   }
+
+   setDirty(dirty: boolean): void {
+      if (dirty === this.dirty) {
+         return;
+      }
+      this.dirty = dirty;
+      this.onDirtyChangedEmitter.fire();
+   }
+}

--- a/packages/form-client/src/common/form-client-protocol.ts
+++ b/packages/form-client/src/common/form-client-protocol.ts
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { JsonRpcServer } from '@theia/core';
+
+export const FormEditorService = Symbol('FormEditorService');
+export const FORM_EDITOR_SERVICE_PATH = '/services/withClient';
+
+export interface CrossModelRoot {
+   readonly $type: 'CrossModelRoot';
+   entity?: Entity;
+   relationship?: Relationship;
+}
+
+export interface Relationship {
+   readonly $type: 'Relationship';
+   name: string;
+   properties: Array<Property>;
+   source: string;
+   target: string;
+   type: '1:1' | '1:n' | 'n:1' | 'n:m';
+}
+
+export interface Property {
+   readonly $type: 'Property';
+   key: string;
+   value: number | string;
+}
+
+export interface Entity {
+   readonly $type: 'Entity';
+   name: string;
+   description: string;
+   attributes: Array<Attribute>;
+}
+
+export interface Attribute {
+   readonly $type: 'Attribute';
+   name: string;
+   value: number | string;
+}
+
+export interface FormEditorService extends JsonRpcServer<FormEditorClient> {
+   open(uri: string): Promise<void>;
+   close(uri: string): Promise<void>;
+   request(uri: string): Promise<CrossModelRoot | undefined>;
+   update(uri: string, model: CrossModelRoot): Promise<void>;
+   save(uri: string, model: CrossModelRoot): Promise<void>;
+}
+
+export const FormEditorClient = Symbol('FormEditorClient');
+export interface FormEditorClient {
+   getName(): Promise<string>;
+}

--- a/packages/form-client/src/node/form-client-backend-module.ts
+++ b/packages/form-client/src/node/form-client-backend-module.ts
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { ConnectionHandler, JsonRpcConnectionHandler } from '@theia/core';
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { FormEditorClient, FormEditorService, FORM_EDITOR_SERVICE_PATH } from '../common/form-client-protocol';
+import { FormEditorServiceImpl } from './form-server';
+
+export default new ContainerModule(bind => {
+   bind(FormEditorService).to(FormEditorServiceImpl).inSingletonScope();
+   bind(ConnectionHandler)
+      .toDynamicValue(
+         ctx =>
+            new JsonRpcConnectionHandler<FormEditorClient>(FORM_EDITOR_SERVICE_PATH, client => {
+               const server = ctx.container.get<FormEditorServiceImpl>(FormEditorService);
+               server.setClient(client);
+               client.onDidCloseConnection(() => server.dispose());
+               return server;
+            })
+      )
+      .inSingletonScope();
+});

--- a/packages/form-client/src/node/form-server.ts
+++ b/packages/form-client/src/node/form-server.ts
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+import { injectable } from '@theia/core/shared/inversify';
+import * as net from 'net';
+import * as rpc from 'vscode-jsonrpc/node';
+import { CrossModelRoot, FormEditorClient, FormEditorService } from '../common/form-client-protocol';
+
+const SOCKET_OPTIONS = { port: 5999, host: 'localhost' };
+const OpenModel = new rpc.RequestType1<string, void, void>('server/open');
+const CloseModel = new rpc.RequestType1<string, void, void>('server/close');
+const RequestModel = new rpc.RequestType1<string, CrossModelRoot | undefined, void>('server/request');
+const UpdateModel = new rpc.RequestType2<string, CrossModelRoot, void, void>('server/update');
+const SaveModel = new rpc.RequestType2<string, CrossModelRoot, void, void>('server/save');
+
+@injectable()
+export class FormEditorServiceImpl implements FormEditorService {
+   protected initialized = false;
+   protected connection: rpc.MessageConnection;
+   protected client?: FormEditorClient;
+
+   async initialize(): Promise<void> {
+      if (this.initialized) {
+         return;
+      }
+      const socket = new net.Socket();
+      const reader = new rpc.SocketMessageReader(socket);
+      const writer = new rpc.SocketMessageWriter(socket);
+      this.connection = rpc.createMessageConnection(reader, writer);
+
+      this.connection.onClose(() => (this.initialized = false));
+      socket.on('close', () => (this.initialized = false));
+
+      socket.connect(SOCKET_OPTIONS);
+      this.connection.listen();
+      this.initialized = true;
+   }
+
+   async open(uri: string): Promise<void> {
+      await this.initialize();
+      await this.connection.sendRequest(OpenModel, uri);
+   }
+
+   async close(uri: string): Promise<void> {
+      await this.initialize();
+      await this.connection.sendRequest(CloseModel, uri);
+   }
+
+   async request(uri: string): Promise<CrossModelRoot | undefined> {
+      await this.initialize();
+      return this.connection.sendRequest(RequestModel, uri);
+   }
+
+   async update(uri: string, model: CrossModelRoot): Promise<void> {
+      await this.initialize();
+      return this.connection.sendRequest(UpdateModel, uri, model);
+   }
+
+   async save(uri: string, model: CrossModelRoot): Promise<void> {
+      await this.initialize();
+      return this.connection.sendRequest(SaveModel, uri, model);
+   }
+
+   dispose(): void {
+      // do nothing
+   }
+
+   setClient(client: FormEditorClient): void {
+      this.client = client;
+   }
+}

--- a/packages/form-client/tsconfig.json
+++ b/packages/form-client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../configs/tsconfig.json",
+    "compilerOptions": {
+      "rootDir": "src",
+      "outDir": "lib"
+    },
+    "include": [
+        "src"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1790,7 +1790,7 @@
     "@theia/monaco-editor-core" "1.72.3"
     anser "^2.0.1"
 
-"@theia/core@1.34.1", "@theia/core@^1.34.1":
+"@theia/core@1.34.1", "@theia/core@^1.34.0", "@theia/core@^1.34.1":
   version "1.34.1"
   resolved "https://registry.yarnpkg.com/@theia/core/-/core-1.34.1.tgz#7be3b45bc57f843c8e6eb6182a7a00d352d7e2df"
   integrity sha512-/6ntniXz6zK4VNgMuukzZKhF6cEUyGzJalAY35BLytVNC7mB08DRpv8P7+AHb7YvRMVNA68K7MQOyWctgMwWbQ==
@@ -13403,7 +13403,7 @@ vhost@^3.0.2:
   resolved "https://registry.yarnpkg.com/vhost/-/vhost-3.0.2.tgz#2fb1decd4c466aa88b0f9341af33dc1aff2478d5"
   integrity sha512-S3pJdWrpFWrKMboRU4dLYgMrTgoPALsmYwOvyebK2M6X95b9kQrjZy5rwl3uzzpfpENe/XrNYu/2U+e7/bmT5g==
 
-vscode-jsonrpc@8.0.2:
+vscode-jsonrpc@8.0.2, vscode-jsonrpc@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz#f239ed2cd6004021b6550af9fd9d3e47eee3cac9"
   integrity sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==
@@ -13422,7 +13422,7 @@ vscode-languageclient@^8.0.2:
     semver "^7.3.7"
     vscode-languageserver-protocol "3.17.3"
 
-vscode-languageserver-protocol@3.17.3:
+vscode-languageserver-protocol@3.17.3, vscode-languageserver-protocol@^3.17.3:
   version "3.17.3"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz#6d0d54da093f0c0ee3060b81612cce0f11060d57"
   integrity sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==
@@ -13443,7 +13443,7 @@ vscode-languageserver-textdocument@^1.0.1:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.7.tgz#16df468d5c2606103c90554ae05f9f3d335b771b"
   integrity sha512-bFJH7UQxlXT8kKeyiyu41r22jCZXG8kuuVVA33OEJn1diWOZK5n8zBSPZFHVBOu8kXZ6h0LIRhf5UnCo61J4Hg==
 
-vscode-languageserver-textdocument@^1.0.7:
+vscode-languageserver-textdocument@^1.0.7, vscode-languageserver-textdocument@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.8.tgz#9eae94509cbd945ea44bca8dcfe4bb0c15bb3ac0"
   integrity sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==


### PR DESCRIPTION
* Add model service that allows to open, close, upate, and save models
* Add JSON RPC editor that exposes the model service API to remote clients
* Add Theia frontend/backend-service that connects to the model server
* Add form editor based on that service that shows relationships and entities
* Enable editing and saving in the form editor

Please note that the code in `extensions/crossmodel-lang/src/model-server` is meant to be entirely generic (i.e. independent of crossmodel) to potentially allow for open-sourcing this generic functionality and benefit from potential enhancements and hardening in other use cases, if this is desired.