### PR TITLE
Feature/attributes graphical view

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -6,7 +6,7 @@ module.exports = {
     trailingComma: 'none',
     endOfLine: 'lf',
     printWidth: 140,
-    tabWidth: 3,
+    tabWidth: 4,
     overrides: [
         {
             files: ['*.json', '*.yml'],

--- a/configs/errors.eslintrc.js
+++ b/configs/errors.eslintrc.js
@@ -67,6 +67,7 @@ module.exports = {
         'no-null/no-null': 'error',
         // chai friendly
         'no-unused-expressions': 'off',
-        'chai-friendly/no-unused-expressions': 'error'
+        'chai-friendly/no-unused-expressions': 'error',
+        'react/react-in-jsx-scope': 'off'
     }
 };

--- a/extensions/crossmodel-lang/src/glsp-server/model/builders/GEntityNode.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/model/builders/GEntityNode.ts
@@ -5,71 +5,71 @@ import { ArgsUtil, GCompartment, GLabel, GNode, GNodeBuilder } from '@eclipse-gl
 import { DiagramNode } from '../../../language-server/generated/ast';
 
 export class GEntityNode extends GNode {
-   override type = 'node:entity';
+    override type = 'node:entity';
 
-   static override builder(): GEntityNodeBuilder {
-      return new GEntityNodeBuilder(GEntityNode).type('node:entity');
-   }
+    static override builder(): GEntityNodeBuilder {
+        return new GEntityNodeBuilder(GEntityNode).type('node:entity');
+    }
 }
 
 export class GEntityNodeBuilder extends GNodeBuilder {
-   addNode(node: DiagramNode): this {
-      // Get the reference that the DiagramNode holds to the Entity in the .langium file.
-      const entityRef = node.semanticElement.ref;
+    addNode(node: DiagramNode): this {
+        // Get the reference that the DiagramNode holds to the Entity in the .langium file.
+        const entityRef = node.semanticElement.ref;
 
-      // Options which are the same for every node
-      this.addCssClasses('diagram-node', 'entity').layout('vbox').addArgs(ArgsUtil.cornerRadius(3));
+        // Options which are the same for every node
+        this.addCssClasses('diagram-node', 'entity').layout('vbox').addArgs(ArgsUtil.cornerRadius(3));
 
-      // We need the id before we can build the label and childeren.
-      if (this.id === undefined) {
-         throw new Error('Add id to builder before adding the node reference.');
-      }
+        // We need the id before we can build the label and childeren.
+        if (this.id === undefined) {
+            throw new Error('Add id to builder before adding the node reference.');
+        }
 
-      // Add the label/name of the node
-      const label = GCompartment.builder()
-         .layout('hbox')
-         .addLayoutOption('hAlign', 'center')
-         .addCssClass('header-container-diagram-node')
-         .add(
-            GLabel.builder()
-               .text(entityRef?.name || 'unresolved')
-               .id(`${this.proxy.id}_label`)
-               .addCssClass('entity-header')
-               .build()
-         )
-         .build();
+        // Add the label/name of the node
+        const label = GCompartment.builder()
+            .layout('hbox')
+            .addLayoutOption('hAlign', 'center')
+            .addCssClass('entity-header-compartment')
+            .add(
+                GLabel.builder()
+                    .text(entityRef?.name || 'unresolved')
+                    .id(`${this.proxy.id}_label`)
+                    .addCssClass('entity-header-label')
+                    .build()
+            )
+            .build();
 
-      this.add(label);
+        this.add(label);
 
-      // Add the children of the node
-      if (entityRef !== undefined) {
-         const allAttributesCompartment = GCompartment.builder()
-            .addCssClass('attributes-compartment')
-            .layout('vbox')
-            .addLayoutOption('hAlign', 'left')
-            .addLayoutOption('paddingBottom', 0);
+        // Add the children of the node
+        if (entityRef !== undefined) {
+            const allAttributesCompartment = GCompartment.builder()
+                .addCssClass('attributes-compartment')
+                .layout('vbox')
+                .addLayoutOption('hAlign', 'left')
+                .addLayoutOption('paddingBottom', 0);
 
-         // Add the attributes of the entity.
-         for (const attribute of entityRef.attributes) {
-            const attributeCompartment = GCompartment.builder()
-               .addCssClass('attribute-compartment')
-               .layout('hbox')
-               .addLayoutOption('paddingBottom', 3)
-               .addLayoutOption('paddingTop', 3);
+            // Add the attributes of the entity.
+            for (const attribute of entityRef.attributes) {
+                const attributeCompartment = GCompartment.builder()
+                    .addCssClass('attribute-compartment')
+                    .layout('hbox')
+                    .addLayoutOption('paddingBottom', 3)
+                    .addLayoutOption('paddingTop', 3);
 
-            attributeCompartment.add(GLabel.builder().text(attribute.name).addCssClass('attribute').build());
-            attributeCompartment.add(GLabel.builder().text(' : ').build());
-            attributeCompartment.add(GLabel.builder().text(attribute.value.toString()).addCssClass('datatype').build());
+                attributeCompartment.add(GLabel.builder().text(attribute.name).addCssClass('attribute').build());
+                attributeCompartment.add(GLabel.builder().text(' : ').build());
+                attributeCompartment.add(GLabel.builder().text(attribute.value.toString()).addCssClass('datatype').build());
 
-            allAttributesCompartment.add(attributeCompartment.build());
-         }
+                allAttributesCompartment.add(attributeCompartment.build());
+            }
 
-         this.add(allAttributesCompartment.build());
-      }
+            this.add(allAttributesCompartment.build());
+        }
 
-      // The DiagramNode in the langium file holds the coordinates of node
-      this.addLayoutOption('prefWidth', node.width).addLayoutOption('prefHeight', node.height).position(node.x, node.y);
+        // The DiagramNode in the langium file holds the coordinates of node
+        this.addLayoutOption('prefWidth', node.width).addLayoutOption('prefHeight', node.height).position(node.x, node.y);
 
-      return this;
-   }
+        return this;
+    }
 }

--- a/extensions/crossmodel-lang/src/glsp-server/model/builders/GEntityNode.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/model/builders/GEntityNode.ts
@@ -5,8 +5,10 @@ import { ArgsUtil, GCompartment, GLabel, GNode, GNodeBuilder } from '@eclipse-gl
 import { DiagramNode } from '../../../language-server/generated/ast';
 
 export class GEntityNode extends GNode {
+   override type = 'node:entity';
+
    static override builder(): GEntityNodeBuilder {
-      return new GEntityNodeBuilder(GEntityNode);
+      return new GEntityNodeBuilder(GEntityNode).type('node:entity');
    }
 }
 
@@ -27,12 +29,12 @@ export class GEntityNodeBuilder extends GNodeBuilder {
       const label = GCompartment.builder()
          .layout('hbox')
          .addLayoutOption('hAlign', 'center')
-         .addLayoutOption('paddingBottom', 0)
          .addCssClass('header-container-diagram-node')
          .add(
             GLabel.builder()
                .text(entityRef?.name || 'unresolved')
                .id(`${this.proxy.id}_label`)
+               .addCssClass('entity-header')
                .build()
          )
          .build();
@@ -52,7 +54,8 @@ export class GEntityNodeBuilder extends GNodeBuilder {
             const attributeCompartment = GCompartment.builder()
                .addCssClass('attribute-compartment')
                .layout('hbox')
-               .addLayoutOption('paddingBottom', 0);
+               .addLayoutOption('paddingBottom', 3)
+               .addLayoutOption('paddingTop', 3);
 
             attributeCompartment.add(GLabel.builder().text(attribute.name).addCssClass('attribute').build());
             attributeCompartment.add(GLabel.builder().text(' : ').build());

--- a/extensions/crossmodel-lang/src/glsp-server/model/builders/GEntityNode.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/model/builders/GEntityNode.ts
@@ -1,0 +1,72 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+import { ArgsUtil, GCompartment, GLabel, GNode, GNodeBuilder } from '@eclipse-glsp/server';
+import { DiagramNode } from '../../../language-server/generated/ast';
+
+export class GEntityNode extends GNode {
+   static override builder(): GEntityNodeBuilder {
+      return new GEntityNodeBuilder(GEntityNode);
+   }
+}
+
+export class GEntityNodeBuilder extends GNodeBuilder {
+   addNode(node: DiagramNode): this {
+      // Get the reference that the DiagramNode holds to the Entity in the .langium file.
+      const entityRef = node.semanticElement.ref;
+
+      // Options which are the same for every node
+      this.addCssClasses('diagram-node', 'entity').layout('vbox').addArgs(ArgsUtil.cornerRadius(3));
+
+      // We need the id before we can build the label and childeren.
+      if (this.id === undefined) {
+         throw new Error('Add id to builder before adding the node reference.');
+      }
+
+      // Add the label/name of the node
+      const label = GCompartment.builder()
+         .layout('hbox')
+         .addLayoutOption('hAlign', 'center')
+         .addLayoutOption('paddingBottom', 0)
+         .addCssClass('header-container-diagram-node')
+         .add(
+            GLabel.builder()
+               .text(entityRef?.name || 'unresolved')
+               .id(`${this.proxy.id}_label`)
+               .build()
+         )
+         .build();
+
+      this.add(label);
+
+      // Add the children of the node
+      if (entityRef !== undefined) {
+         const allAttributesCompartment = GCompartment.builder()
+            .addCssClass('attributes-compartment')
+            .layout('vbox')
+            .addLayoutOption('hAlign', 'left')
+            .addLayoutOption('paddingBottom', 0);
+
+         // Add the attributes of the entity.
+         for (const attribute of entityRef.attributes) {
+            const attributeCompartment = GCompartment.builder()
+               .addCssClass('attribute-compartment')
+               .layout('hbox')
+               .addLayoutOption('paddingBottom', 0);
+
+            attributeCompartment.add(GLabel.builder().text(attribute.name).addCssClass('attribute').build());
+            attributeCompartment.add(GLabel.builder().text(' : ').build());
+            attributeCompartment.add(GLabel.builder().text(attribute.value.toString()).addCssClass('datatype').build());
+
+            allAttributesCompartment.add(attributeCompartment.build());
+         }
+
+         this.add(allAttributesCompartment.build());
+      }
+
+      // The DiagramNode in the langium file holds the coordinates of node
+      this.addLayoutOption('prefWidth', node.width).addLayoutOption('prefHeight', node.height).position(node.x, node.y);
+
+      return this;
+   }
+}

--- a/extensions/crossmodel-lang/src/glsp-server/model/cross-model-gmodel-factory.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/model/cross-model-gmodel-factory.ts
@@ -1,10 +1,11 @@
 /********************************************************************************
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
-import { GEdge, GGraph, GLabel, GModelFactory, GNode } from '@eclipse-glsp/server';
+import { GEdge, GGraph, GModelFactory, GNode } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import { DiagramEdge, DiagramNode } from '../../language-server/generated/ast';
 import { CrossModelState } from './cross-model-state';
+import { GEntityNode } from './builders/GEntityNode';
 
 @injectable()
 export class CrossModelGModelFactory implements GModelFactory {
@@ -19,29 +20,18 @@ export class CrossModelGModelFactory implements GModelFactory {
 
    protected createGraph(): GGraph | undefined {
       const diagramRoot = this.modelState.diagramRoot;
+
       const graphBuilder = GGraph.builder().id(this.modelState.semanticUri);
       diagramRoot.nodes.map(node => this.createDiagramNode(node)).forEach(node => graphBuilder.add(node));
       diagramRoot.edges.map(edge => this.createDiagramEdge(edge)).forEach(edge => graphBuilder.add(edge));
+
       return graphBuilder.build();
    }
 
    protected createDiagramNode(node: DiagramNode): GNode {
+      // Get the reference that the DiagramNode holds to the Entity in the .langium file.
       const id = this.modelState.index.createId(node) ?? 'unknown';
-      const label = GLabel.builder()
-         .text(node.semanticElement.ref?.name || 'unresolved')
-         .id(`${id}_label`)
-         .build();
-
-      return GNode.builder()
-         .id(id)
-         .addCssClasses('diagram-node', 'entity')
-         .add(label)
-         .layout('hbox')
-         .addLayoutOption('prefWidth', node.width)
-         .addLayoutOption('prefHeight', node.height)
-         .position(node.x, node.y)
-         .addLayoutOption('paddingLeft', 5)
-         .build();
+      return GEntityNode.builder().id(id).addNode(node).build();
    }
 
    protected createDiagramEdge(edge: DiagramEdge): GEdge {

--- a/packages/glsp-client/src/browser/crossmodel-diagram-module.ts
+++ b/packages/glsp-client/src/browser/crossmodel-diagram-module.ts
@@ -3,6 +3,7 @@
  ********************************************************************************/
 import {
    configureDefaultModelElements,
+   configureModelElement,
    ConsoleLogger,
    createDiagramContainer,
    LogLevel,
@@ -10,12 +11,16 @@ import {
    TYPES
 } from '@eclipse-glsp/client';
 import { Container, ContainerModule } from '@theia/core/shared/inversify';
+import { EntityNodeView } from '../views';
+import { EntityNode } from '../model';
 
 const crossModelDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
    rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
    rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn);
    const context = { bind, unbind, isBound, rebind };
    configureDefaultModelElements(context);
+
+   configureModelElement(context, 'node:entity', EntityNode, EntityNodeView);
 });
 
 export default function createCrossModelDiagramContainer(widgetId: string): Container {

--- a/packages/glsp-client/src/browser/crossmodel-diagram-module.ts
+++ b/packages/glsp-client/src/browser/crossmodel-diagram-module.ts
@@ -2,34 +2,38 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 import {
-   configureDefaultModelElements,
-   configureModelElement,
-   ConsoleLogger,
-   createDiagramContainer,
-   LogLevel,
-   overrideViewerOptions,
-   TYPES
+    configureDefaultModelElements,
+    configureModelElement,
+    ConsoleLogger,
+    createDiagramContainer,
+    LogLevel,
+    overrideViewerOptions,
+    TYPES
 } from '@eclipse-glsp/client';
 import { Container, ContainerModule } from '@theia/core/shared/inversify';
 import { EntityNodeView } from '../views';
 import { EntityNode } from '../model';
 
 const crossModelDiagramModule = new ContainerModule((bind, unbind, isBound, rebind) => {
-   rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
-   rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn);
-   const context = { bind, unbind, isBound, rebind };
-   configureDefaultModelElements(context);
+    rebind(TYPES.ILogger).to(ConsoleLogger).inSingletonScope();
+    rebind(TYPES.LogLevel).toConstantValue(LogLevel.warn);
+    const context = { bind, unbind, isBound, rebind };
+    configureDefaultModelElements(context);
 
-   configureModelElement(context, 'node:entity', EntityNode, EntityNodeView);
+    // Bind views that can be rendered by the client-side
+    // The glsp-server can send a request to render a specific view given a type, e.g. node:entity
+    // The model class holds the client-side model and properties
+    // The view class shows how to draw the svg element given the properties of the model class
+    configureModelElement(context, 'node:entity', EntityNode, EntityNodeView);
 });
 
 export default function createCrossModelDiagramContainer(widgetId: string): Container {
-   const container = createDiagramContainer(crossModelDiagramModule);
+    const container = createDiagramContainer(crossModelDiagramModule);
 
-   overrideViewerOptions(container, {
-      baseDiv: widgetId,
-      hiddenDiv: widgetId + '_hidden'
-   });
+    overrideViewerOptions(container, {
+        baseDiv: widgetId,
+        hiddenDiv: widgetId + '_hidden'
+    });
 
-   return container;
+    return container;
 }

--- a/packages/glsp-client/src/model.ts
+++ b/packages/glsp-client/src/model.ts
@@ -1,0 +1,7 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { RectangularNode } from 'sprotty/lib';
+
+export class EntityNode extends RectangularNode {}

--- a/packages/glsp-client/src/views.tsx
+++ b/packages/glsp-client/src/views.tsx
@@ -22,7 +22,7 @@ export class EntityNodeView extends RectangularNodeView {
                         <feDropShadow dx='0.5' dy='0.5' stdDeviation='0.4' />
                     </filter>
                 </defs>
-                <rect x={0} y={0} rx={6} ry={6} width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)} />
+                <rect x={0} y={0} rx={6} width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)} />
 
                 {/* The renderChildren function will render SVG objects for the children of the node object. */}
                 {/* TODO: Check with ES how to fix the mentioned problem below. */}

--- a/packages/glsp-client/src/views.tsx
+++ b/packages/glsp-client/src/views.tsx
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+
+import { injectable } from 'inversify';
+import { VNode } from 'snabbdom';
+import { RenderingContext, svg, RectangularNodeView } from 'sprotty/lib';
+import { EntityNode } from './model';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const JSX = { createElement: svg };
+
+@injectable()
+export class EntityNodeView extends RectangularNodeView {
+    override render(node: EntityNode, context: RenderingContext): VNode {
+        const rhombStr = 'M 0,28  L ' + node.bounds.width + ',28';
+
+        const classNode: any = (
+            <g>
+                <defs>
+                    <filter id='dropShadow'>
+                        <feDropShadow dx='0.5' dy='0.5' stdDeviation='0.4' />
+                    </filter>
+                </defs>
+                <rect x={0} y={0} rx={6} ry={6} width={Math.max(0, node.bounds.width)} height={Math.max(0, node.bounds.height)} />
+
+                {/* The renderChildren function will render SVG objects for the children of the node object. */}
+                {/* TODO: Check with ES how to fix the mentioned problem below. */}
+                {context.renderChildren(node)}
+
+                {node.children[1] && node.children[1].children.length > 0 ? <path d={rhombStr}></path> : ''}
+            </g>
+        );
+
+        return classNode;
+    }
+}

--- a/packages/glsp-client/style/diagram.css
+++ b/packages/glsp-client/style/diagram.css
@@ -27,6 +27,11 @@
 .diagram-node {
    fill: #fffcdf;
    stroke: black;
+   filter: url(#dropShadow);
+}
+
+.entity-header {
+   font-weight: bold;
 }
 
 .diagram-node > .sprotty-node:not(.selected) {

--- a/packages/glsp-client/style/diagram.css
+++ b/packages/glsp-client/style/diagram.css
@@ -2,6 +2,45 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 
-.entity > .sprotty-node {
-   fill: #5c87bd;
+:root {
+   --sprotty-background: var(--theia-layout-color3);
+   --sprotty-edge: var(--theia-editor-foreground);
+   --sprotty-border: var(--theia-editor-foreground);
+}
+
+/* Standard sprotty */
+.sprotty {
+   height: 100%;
+}
+
+.sprotty-graph .sprotty-node {
+   fill: inherit;
+}
+
+.sprotty-graph {
+   font-size: 15pt;
+   height: 100%;
+   background: var(--sprotty-background);
+}
+
+/* Nodes */
+.diagram-node {
+   fill: #fffcdf;
+   stroke: black;
+}
+
+.diagram-node > .sprotty-node:not(.selected) {
+   stroke-width: 1px;
+}
+
+.header-container-diagram-node {
+   stroke: 1;
+}
+
+.sprotty-node.mouseover:not(.selected) {
+   stroke-width: 3px;
+}
+
+.sprotty-node.selected {
+   stroke-width: 5px;
 }

--- a/packages/glsp-client/style/diagram.css
+++ b/packages/glsp-client/style/diagram.css
@@ -3,49 +3,49 @@
  ********************************************************************************/
 
 :root {
-   --sprotty-background: var(--theia-layout-color3);
-   --sprotty-edge: var(--theia-editor-foreground);
-   --sprotty-border: var(--theia-editor-foreground);
+    --sprotty-background: var(--theia-layout-color3);
+    --sprotty-edge: var(--theia-editor-foreground);
+    --sprotty-border: var(--theia-editor-foreground);
 }
 
 /* Standard sprotty */
 .sprotty {
-   height: 100%;
+    height: 100%;
 }
 
 .sprotty-graph .sprotty-node {
-   fill: inherit;
+    fill: inherit;
 }
 
 .sprotty-graph {
-   font-size: 15pt;
-   height: 100%;
-   background: var(--sprotty-background);
+    font-size: 15pt;
+    height: 100%;
+    background: var(--sprotty-background);
 }
 
 /* Nodes */
 .diagram-node {
-   fill: #fffcdf;
-   stroke: black;
-   filter: url(#dropShadow);
+    fill: #fffcdf;
+    stroke: black;
+    filter: url(#dropShadow);
 }
 
 .entity-header {
-   font-weight: bold;
+    font-weight: bold;
 }
 
 .diagram-node > .sprotty-node:not(.selected) {
-   stroke-width: 1px;
+    stroke-width: 1px;
 }
 
 .header-container-diagram-node {
-   stroke: 1;
+    stroke: 1;
 }
 
 .sprotty-node.mouseover:not(.selected) {
-   stroke-width: 3px;
+    stroke-width: 3px;
 }
 
 .sprotty-node.selected {
-   stroke-width: 5px;
+    stroke-width: 5px;
 }

--- a/packages/glsp-client/tsconfig.json
+++ b/packages/glsp-client/tsconfig.json
@@ -2,7 +2,9 @@
     "extends": "../../configs/tsconfig.json",
     "compilerOptions": {
       "rootDir": "src",
-      "outDir": "lib"
+      "outDir": "lib",
+      "jsx":"react",
+      "reactNamespace":"JSX"
     },
     "include": [
         "src"


### PR DESCRIPTION
Started working on the userstory USER STORY 705.

Done:
- Built a gmodel class named [GEntityNode.ts](https://github.com/CrossBreezeNL/crossmodel/compare/main...feature/attributes-graphical-view#diff-a14bfbe748820a1051bd51c88f9cd96b049fbf0af7097bc512891723acd6eb2a) to build sever side entity nodes.
- Built RectangularNodeView in [views.tsx](https://github.com/CrossBreezeNL/crossmodel/compare/main...feature/attributes-graphical-view#diff-138e8db9222d799a38945d862fd2c2dc44960f7962d2ed8f42be6a1bac8657c5) to render an entity node server side.
- Added css

Still missing:
- Documentation (WIP)
- Test (How are we going to do this?)



