### PR TITLE
Add support for textual expressions in attribute mappings

### DIFF
--- a/examples/mapping-example/ExampleDWH/CompleteCustomerMapping.mapping.cm
+++ b/examples/mapping-example/ExampleDWH/CompleteCustomerMapping.mapping.cm
@@ -15,14 +15,22 @@ mapping:
         entity: ExampleDWH.CompleteCustomer
         mappings:
           - attribute: Country
-            source: CustomerSourceObject.Country
+            sources:
+              - CustomerSourceObject.Country
           - attribute: FixedNumber
-            source: 1
+            sources:
+              - 1
           - attribute: FixedString
-            source: "Hoppa"
+            sources:
+              - "Hoppa"
           - attribute: Name
-            source: CustomerSourceObject.FirstName
+            sources:
+              - CustomerSourceObject.FirstName
+              - CustomerSourceObject.LastName
+            expression: "CONCAT_WS({{CustomerSourceObject.FirstName}}, {{CustomerSourceObject.LastName}}, ' ')"
           - attribute: Age
-            source: CalcAgeSourceObject.Age
-          - attribute: Age
-            source: CalcAgeSourceObject.Age
+            sources:
+              - CustomerSourceObject.BirthDate
+            expression: "DATEDIFF(YEAR, NOW(), {{CustomerSourceObject.BirthDate}})"
+          - attribute: Today
+            expression: "GETDATE()"

--- a/examples/mapping-example/ExampleDWH/DWH.mapping.cm
+++ b/examples/mapping-example/ExampleDWH/DWH.mapping.cm
@@ -28,14 +28,20 @@ mapping:
         entity: CompleteCustomer
         mappings:
           - attribute: Name
-            source: Customer.FirstName
+            sources:
+              - Customer.FirstName
           - attribute: Name
-            source: Customer.LastName
+            sources:
+              - Customer.LastName
           - attribute: Country
-            source: Country.Name
+            sources:
+              - Country.Name
           - attribute: Age
-            source: CalcAgeSourceObject.Age
+            sources:
+              - CalcAgeSourceObject.Age
           - attribute: FixedNumber
-            source: 1337
+            sources:
+              - 1337
           - attribute: FixedString
-            source: "Fixed String"
+            sources:
+              - "Fixed String"

--- a/examples/mapping-example/ExampleDWH/entities/CompleteCustomer.entity.cm
+++ b/examples/mapping-example/ExampleDWH/entities/CompleteCustomer.entity.cm
@@ -17,3 +17,6 @@ entity:
         - id: FixedString
           name: "FixedString"
           datatype: "Varchar"
+        - id: Today
+          name: "Today"
+          datatype: "Date"

--- a/extensions/crossmodel-lang/src/glsp-server/common/cross-model-index.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/common/cross-model-index.ts
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
-import { GModelIndex } from '@eclipse-glsp/server';
+import { GModelElement, GModelIndex } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import { AstNode, streamAst } from 'langium';
 import * as uuid from 'uuid';
@@ -64,5 +64,14 @@ export class CrossModelIndex extends GModelIndex {
          return guard(semanticNode) ? semanticNode : undefined;
       }
       return semanticNode;
+   }
+
+   protected override doIndex(element: GModelElement): void {
+      if (this.idToElement.has(element.id)) {
+         // super method throws error which is a bit too extreme, simply log the error to the client
+         this.services.shared.logger.ClientLogger.error('Duplicate element id in graph: ' + element.id);
+         return;
+      }
+      super.doIndex(element);
    }
 }

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/edges.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/edges.ts
@@ -4,27 +4,28 @@
 
 import { TARGET_ATTRIBUTE_MAPPING_EDGE_TYPE, createLeftPortId, createRightPortId } from '@crossbreeze/protocol';
 import { GEdge, GEdgeBuilder } from '@eclipse-glsp/server';
-import { AttributeMapping, isReferenceSource } from '../../../language-server/generated/ast.js';
+import { AttributeMappingSource, isReferenceSource } from '../../../language-server/generated/ast.js';
 import { MappingModelIndex } from './mapping-model-index.js';
 
 export class GTargetObjectEdge extends GEdge {
    override type = TARGET_ATTRIBUTE_MAPPING_EDGE_TYPE;
 
-   static override builder(): GTargeMappingEdgeBuilder {
-      return new GTargeMappingEdgeBuilder(GTargetObjectEdge).type(TARGET_ATTRIBUTE_MAPPING_EDGE_TYPE);
+   static override builder(): GTargetMappingSourceEdgeBuilder {
+      return new GTargetMappingSourceEdgeBuilder(GTargetObjectEdge).type(TARGET_ATTRIBUTE_MAPPING_EDGE_TYPE);
    }
 }
 
-export class GTargeMappingEdgeBuilder extends GEdgeBuilder<GTargetObjectEdge> {
-   set(mapping: AttributeMapping, index: MappingModelIndex): this {
-      this.id(index.createId(mapping));
+export class GTargetMappingSourceEdgeBuilder extends GEdgeBuilder<GTargetObjectEdge> {
+   set(source: AttributeMappingSource, index: MappingModelIndex): this {
+      const mapping = source.$container;
+      const sourceId = isReferenceSource(source) ? createRightPortId(index.createId(source.value.ref)) : index.createId(source);
+      const targetId = createLeftPortId(index.createId(mapping.attribute));
+
+      const id = 'edge_' + index.createId(source);
+      this.id(id);
+      index.indexSemanticElement(id, source);
       this.addCssClasses('diagram-edge', 'mapping-edge', 'attribute-mapping');
       this.addArg('edgePadding', 5);
-
-      const sourceId = isReferenceSource(mapping.source)
-         ? createRightPortId(index.createId(mapping.source.value.ref))
-         : index.createId(mapping.source);
-      const targetId = createLeftPortId(index.createId(mapping.attribute));
 
       this.sourceId(sourceId);
       this.targetId(targetId);

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/mapping-diagram-gmodel-factory.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/mapping-diagram-gmodel-factory.ts
@@ -39,7 +39,8 @@ export class MappingDiagramGModelFactory implements GModelFactory {
 
       // literals that serve as source
       mappingRoot.target.mappings
-         .map(mapping => this.createSourceLiteralNode(mapping.source))
+         .flatMap(mapping => mapping.sources)
+         .map(source => this.createSourceLiteralNode(source))
          .filter(node => node !== undefined)
          .forEach(node => graphBuilder.add(node!));
 
@@ -47,13 +48,13 @@ export class MappingDiagramGModelFactory implements GModelFactory {
       graphBuilder.add(this.createTargetNode(mappingRoot.target));
 
       // attribute mapping edges
-      mappingRoot.target.mappings.map(mapping => this.createTargetObjectEdge(mapping)).forEach(edge => graphBuilder.add(edge));
+      mappingRoot.target.mappings.flatMap(mapping => this.createTargetObjectEdge(mapping)).forEach(edge => graphBuilder.add(edge));
 
       return graphBuilder.build();
    }
 
-   protected createTargetObjectEdge(attribute: AttributeMapping): GEdge {
-      return GTargetObjectEdge.builder().set(attribute, this.modelState.index).build();
+   protected createTargetObjectEdge(attribute: AttributeMapping): GEdge[] {
+      return attribute.sources.map(src => GTargetObjectEdge.builder().set(src, this.modelState.index).build());
    }
 
    protected createSourceObjectNode(sourceObject: SourceObject): GNode {

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/mapping-model-index.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/mapping-model-index.ts
@@ -57,7 +57,7 @@ export class MappingModelIndex extends CrossModelIndex {
    }
 
    protected createAttributeMappingId(mapping: AttributeMapping): string | undefined {
-      const sourceId = this.findId(mapping.source);
+      const sourceId = mapping.sources.map(source => this.findId(source)).join('_');
       const targetId = this.findId(mapping.attribute);
       return `${mapping.$containerIndex ?? 0}_${sourceId}_to_${targetId}`;
    }
@@ -71,11 +71,11 @@ export class MappingModelIndex extends CrossModelIndex {
    }
 
    protected createLiteralId(literal: NumberLiteral | StringLiteral): string {
-      return `mapping_${literal.$container?.$containerIndex ?? 0}_source_${literal.value}`;
+      return `mapping_${literal.$container?.$containerIndex ?? 0}_source_${literal.$containerIndex ?? 0}_${literal.value}`;
    }
 
    protected createReferenceSourceId(source: ReferenceSource): string | undefined {
-      return `mapping_${source.$container?.$containerIndex ?? 0}_source_${this.createId(source.value.ref)}`;
+      return `mapping_${source.$container?.$containerIndex ?? 0}_source_${source.$containerIndex ?? 0}_${this.createId(source.value.ref)}`;
    }
 
    protected getIndex(node: AstNode): number {

--- a/extensions/crossmodel-lang/src/language-server/cross-model-completion-provider.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-completion-provider.ts
@@ -17,9 +17,8 @@ import { v4 as uuid } from 'uuid';
 import { CompletionItemKind, InsertTextFormat, TextEdit } from 'vscode-languageserver-protocol';
 import type { Range } from 'vscode-languageserver-types';
 import { CrossModelServices } from './cross-model-module.js';
-import { RelationshipAttribute, isAttributeMapping, isReferenceSource } from './generated/ast.js';
+import { AttributeMapping, RelationshipAttribute, isAttributeMapping, isReferenceSource } from './generated/ast.js';
 import { fixDocument } from './util/ast-util.js';
-import { isExpressionStart } from '@crossbreeze/protocol';
 
 /**
  * Custom completion provider that only shows the short options to the user if a longer, fully-qualified version is also available.
@@ -28,7 +27,7 @@ export class CrossModelCompletionProvider extends DefaultCompletionProvider {
    protected packageId?: string;
 
    readonly completionOptions = {
-      triggerCharacters: ['\n', ' ']
+      triggerCharacters: ['\n', ' ', '{']
    };
 
    constructor(
@@ -74,18 +73,7 @@ export class CrossModelCompletionProvider extends DefaultCompletionProvider {
          return this.completionForId(context, assignment, acceptor);
       }
       if (isAttributeMapping(context.node) && assignment.feature === 'expression') {
-         const node = context.node;
-         const text = context.textDocument.getText();
-         const existingText = text.substring(context.tokenOffset, context.offset);
-         if (isExpressionStart(existingText)) {
-            node.sources.filter(isReferenceSource).forEach(source => {
-               acceptor(context, {
-                  label: source.value.$refText,
-                  textEdit: TextEdit.insert(context.textDocument.positionAt(context.offset), source.value.$refText)
-               });
-            });
-            return;
-         }
+         return this.completeAttributeMappingExpression(context, context.node, acceptor);
       }
       if (GrammarAST.isRuleCall(assignment.terminal) && assignment.terminal.rule.ref) {
          const type = this.getRuleType(assignment.terminal.rule.ref);
@@ -98,6 +86,33 @@ export class CrossModelCompletionProvider extends DefaultCompletionProvider {
                return this.completionForBoolean(context, assignment, acceptor);
          }
       }
+   }
+
+   protected completeAttributeMappingExpression(
+      context: CompletionContext,
+      mapping: AttributeMapping,
+      acceptor: CompletionAcceptor
+   ): MaybePromise<void> {
+      const text = context.textDocument.getText();
+      const expressionUpToCursor = text.substring(context.tokenOffset, context.offset);
+      const referenceStart = expressionUpToCursor.lastIndexOf('{{');
+      const referenceEnd = expressionUpToCursor.lastIndexOf('}}');
+      if (referenceEnd >= referenceStart) {
+         // we are not within a reference part
+         return;
+      }
+      const start = context.textDocument.positionAt(context.tokenOffset + referenceStart + '{{'.length);
+      const end = context.textDocument.positionAt(context.offset);
+      const reference = context.textDocument.getText({ start, end }).trim();
+      mapping.sources
+         .filter(isReferenceSource)
+         .filter(source => reference.length === 0 || source.value.$refText.startsWith(reference))
+         .forEach(source => {
+            acceptor(context, {
+               label: source.value.$refText,
+               textEdit: TextEdit.replace({ start, end }, source.value.$refText)
+            });
+         });
    }
 
    protected getRuleType(rule: GrammarAST.AbstractRule): string | undefined {

--- a/extensions/crossmodel-lang/src/language-server/cross-model-serializer.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-serializer.ts
@@ -42,15 +42,16 @@ const PROPERTY_ORDER = [
    'relationship',
    'sourceNode',
    'targetNode',
+   'attribute',
    'sources',
    'target',
    'object',
    'join',
    'relations',
    'mappings',
-   'attribute',
    'source',
-   'conditions'
+   'conditions',
+   'expression'
 ];
 
 const ID_OR_IDREF = [
@@ -61,6 +62,7 @@ const ID_OR_IDREF = [
    'targetNode',
    'object',
    'source',
+   'sources',
    'target',
    'attribute',
    'from',
@@ -71,7 +73,7 @@ const ID_OR_IDREF = [
 ];
 
 /** Mapping from JavaScript property keys (AST) to YAML property keys (Grammar). */
-const PROPERTY_TO_KEY_MAP = new Map([['expression', 'join']]);
+const PROPERTY_TO_KEY_MAP = new Map();
 
 /**
  * Hand-written AST serializer as there is currently no out-of-the box serializer from Langium, but it is on the roadmap.
@@ -137,17 +139,18 @@ export class CrossModelSerializer implements Serializer<CrossModelRoot> {
    private serializeArray(arr: any[], indentationLevel: number, key: string): string {
       const serializedItems = arr
          .map(item => this.serializeValue(item, indentationLevel, key))
-         .map(item => this.changeCharInString(item, indentationLevel + CrossModelSerializer.INDENTATION_AMOUNT_ARRAY, '-'))
+         .map(item => this.ensureArrayItem(item, indentationLevel + CrossModelSerializer.INDENTATION_AMOUNT_ARRAY))
          .join(CrossModelSerializer.CHAR_NEWLINE);
       return serializedItems;
    }
 
-   private changeCharInString(inputString: string, indexToChange: number, newChar: any): string {
-      if (indexToChange < 0 || indexToChange >= inputString.length) {
-         throw Error('invalid');
+   private ensureArrayItem(input: any, indentationLevel: number): string {
+      if (indentationLevel < 0) {
+         return input;
       }
 
-      const modifiedString = inputString.slice(0, indexToChange) + newChar + inputString.slice(indexToChange + 1);
+      const indentation = CrossModelSerializer.CHAR_INDENTATION.repeat(indentationLevel);
+      const modifiedString = indentation + '- ' + input.toString().trimStart();
       return modifiedString;
    }
 

--- a/extensions/crossmodel-lang/src/language-server/generated/ast.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/ast.ts
@@ -64,7 +64,8 @@ export interface AttributeMapping extends AstNode {
     readonly $container: TargetObject;
     readonly $type: 'AttributeMapping';
     attribute: AttributeMappingTarget
-    source: AttributeMappingSource
+    expression?: string
+    sources: Array<AttributeMappingSource>
 }
 
 export const AttributeMapping = 'AttributeMapping';
@@ -136,7 +137,7 @@ export function isEntityNode(item: unknown): item is EntityNode {
 export interface JoinCondition extends AstNode {
     readonly $container: SourceObjectRelations;
     readonly $type: 'JoinCondition';
-    expression: JoinExpression
+    join: JoinExpression
 }
 
 export const JoinCondition = 'JoinCondition';
@@ -465,6 +466,14 @@ export class CrossModelAstReflection extends AbstractAstReflection {
 
     getTypeMetaData(type: string): TypeMetaData {
         switch (type) {
+            case 'AttributeMapping': {
+                return {
+                    name: 'AttributeMapping',
+                    mandatory: [
+                        { name: 'sources', type: 'array' }
+                    ]
+                };
+            }
             case 'Entity': {
                 return {
                     name: 'Entity',

--- a/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
@@ -1780,7 +1780,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           },
           {
             "$type": "Assignment",
-            "feature": "expression",
+            "feature": "join",
             "operator": "=",
             "terminal": {
               "$type": "RuleCall",
@@ -1994,24 +1994,80 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             }
           },
           {
-            "$type": "Keyword",
-            "value": "source"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "source",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@28"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "sources"
               },
-              "arguments": []
-            }
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@9"
+                },
+                "arguments": []
+              },
+              {
+                "$type": "Group",
+                "elements": [
+                  {
+                    "$type": "Keyword",
+                    "value": "-"
+                  },
+                  {
+                    "$type": "Assignment",
+                    "feature": "sources",
+                    "operator": "+=",
+                    "terminal": {
+                      "$type": "RuleCall",
+                      "rule": {
+                        "$ref": "#/rules@28"
+                      },
+                      "arguments": []
+                    }
+                  }
+                ],
+                "cardinality": "+"
+              },
+              {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@8"
+                },
+                "arguments": []
+              }
+            ],
+            "cardinality": "?"
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "expression"
+              },
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "expression",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@4"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "?"
           }
         ]
       },

--- a/extensions/crossmodel-lang/src/language-server/mapping.langium
+++ b/extensions/crossmodel-lang/src/language-server/mapping.langium
@@ -49,7 +49,7 @@ RelationshipCondition:
 ;
 
 JoinCondition:
-    'join' ':' expression=JoinExpression
+    'join' ':' join=JoinExpression
 ;
 
 JoinExpression:
@@ -69,7 +69,12 @@ TargetObject:
 
 AttributeMapping:
     'attribute' ':' attribute=AttributeMappingTarget
-    'source' ':' source=AttributeMappingSource
+    ('sources' ':' 
+        INDENT 
+            ('-' sources+=AttributeMappingSource)+     
+        DEDENT
+    )?
+    ('expression' ':' expression=STRING)?
 ;
 
 AttributeMappingTarget:

--- a/extensions/crossmodel-lang/src/language-server/util/ast-util.ts
+++ b/extensions/crossmodel-lang/src/language-server/util/ast-util.ts
@@ -115,7 +115,7 @@ export function createAttributeMapping(
       $type: AttributeMapping,
       $container: container
    } as AttributeMapping;
-   mapping.source = asLiteral || typeof source === 'number' ? createLiteral(mapping, source) : createReferenceSource(mapping, source);
+   mapping.sources = asLiteral || typeof source === 'number' ? [createLiteral(mapping, source)] : [createReferenceSource(mapping, source)];
    mapping.attribute = createAttributeMappingTarget(mapping, targetId);
    return mapping;
 }

--- a/extensions/crossmodel-lang/syntaxes/cross-model.tmLanguage.json
+++ b/extensions/crossmodel-lang/syntaxes/cross-model.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.cross-model",
-      "match": "\\b(apply|attribute|attributes|child|conditions|cross-join|datatype|description|diagram|edges|entity|from|height|id|inner-join|join|left-join|mapping|mappings|name|nodes|parent|relations|relationship|source|sourceNode|sources|systemDiagram|target|targetNode|type|width|x|y)\\b"
+      "match": "\\b(apply|attribute|attributes|child|conditions|cross-join|datatype|description|diagram|edges|entity|expression|from|height|id|inner-join|join|left-join|mapping|mappings|name|nodes|parent|relations|relationship|source|sourceNode|sources|systemDiagram|target|targetNode|type|width|x|y)\\b"
     },
     {
       "name": "string.quoted.double.cross-model",

--- a/packages/glsp-client/src/browser/crossmodel-selection-data-service.ts
+++ b/packages/glsp-client/src/browser/crossmodel-selection-data-service.ts
@@ -35,14 +35,16 @@ export function getElementInfo(element: GModelElement): GModelElementInfo {
       const referenceProperty = element.args[REFERENCE_PROPERTY];
       const referenceContainerType = element.args[REFERENCE_CONTAINER_TYPE];
       const referenceValue = element.args[REFERENCE_VALUE];
-      return {
-         type: element.type,
-         reference: {
-            container: { globalId: element.id, type: referenceContainerType.toString() },
-            property: referenceProperty.toString(),
-            value: referenceValue.toString()
-         }
-      };
+      if (referenceProperty && referenceContainerType && referenceValue) {
+         return {
+            type: element.type,
+            reference: {
+               container: { globalId: element.id, type: referenceContainerType.toString() },
+               property: referenceProperty.toString(),
+               value: referenceValue.toString()
+            }
+         };
+      }
    }
    return { type: element.type };
 }

--- a/packages/glsp-client/src/browser/mapping-diagram/mapping-diagram-frontend-module.ts
+++ b/packages/glsp-client/src/browser/mapping-diagram/mapping-diagram-frontend-module.ts
@@ -2,10 +2,17 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 
-import { ContainerContext, DiagramConfiguration, GLSPDiagramWidget, GLSPTheiaFrontendModule } from '@eclipse-glsp/theia-integration';
+import {
+   ContainerContext,
+   DiagramConfiguration,
+   GLSPDiagramWidget,
+   GLSPTheiaFrontendModule,
+   registerDiagramManager
+} from '@eclipse-glsp/theia-integration';
 
 import { MappingDiagramLanguage } from '../../common/crossmodel-diagram-language';
 import { MappingDiagramConfiguration } from './mapping-diagram-configuration';
+import { MappingDiagramManager } from './mapping-diagram-manager';
 import { MappingDiagramWidget } from './mapping-diagram-widget';
 
 export class MappingDiagramModule extends GLSPTheiaFrontendModule {
@@ -26,6 +33,11 @@ export class MappingDiagramModule extends GLSPTheiaFrontendModule {
    override bindDiagramWidgetFactory(context: ContainerContext): void {
       super.bindDiagramWidgetFactory(context);
       context.rebind(GLSPDiagramWidget).to(MappingDiagramWidget);
+   }
+
+   override configureDiagramManager(context: ContainerContext): void {
+      context.bind(MappingDiagramManager).toSelf().inSingletonScope();
+      registerDiagramManager(context.bind, MappingDiagramManager, false);
    }
 }
 

--- a/packages/glsp-client/src/browser/mapping-diagram/mapping-diagram-manager.ts
+++ b/packages/glsp-client/src/browser/mapping-diagram/mapping-diagram-manager.ts
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2024 CrossBreeze.
+ ********************************************************************************/
+
+import { GLSPDiagramManager } from '@eclipse-glsp/theia-integration';
+import { URI } from '@theia/core';
+import { WidgetOpenerOptions } from '@theia/core/lib/browser';
+import { injectable } from '@theia/core/shared/inversify';
+import { MappingDiagramLanguage } from '../../common/crossmodel-diagram-language';
+import { codiconCSSString } from '@eclipse-glsp/client';
+
+export interface ProblemMarkerOpenerOptions extends WidgetOpenerOptions {
+   selection?: Range;
+}
+
+@injectable()
+export class MappingDiagramManager extends GLSPDiagramManager {
+   get label(): string {
+      return MappingDiagramLanguage.label;
+   }
+
+   override get iconClass(): string {
+      return MappingDiagramLanguage.iconClass ?? codiconCSSString('type-hierarchy-sub');
+   }
+
+   override get fileExtensions(): string[] {
+      return MappingDiagramLanguage.fileExtensions;
+   }
+
+   override get diagramType(): string {
+      return MappingDiagramLanguage.diagramType;
+   }
+
+   override get contributionId(): string {
+      return MappingDiagramLanguage.contributionId;
+   }
+
+   override canHandle(uri: URI, options?: ProblemMarkerOpenerOptions | undefined): number {
+      if (options?.selection) {
+         return 0;
+      }
+      return super.canHandle(uri, options);
+   }
+}

--- a/packages/protocol/src/expression.ts
+++ b/packages/protocol/src/expression.ts
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2024 CrossBreeze.
+ ********************************************************************************/
+
+export const EXPRESSION_REGEX = /{{(.*?)}}/g;
+
+export function findAllExpressions(text?: string): RegExpMatchArray[] {
+   return text ? Array.from(text.matchAll(EXPRESSION_REGEX)) : [];
+}
+
+export function findAllExpressionContents(text: string | undefined, trim = true): string[] {
+   return findAllExpressions(text).map(match => getExpressionText(match, trim));
+}
+
+export function getExpressionPosition(expression: RegExpMatchArray): number {
+   return expression.index ?? 0;
+}
+
+export function getExpression(expression: RegExpMatchArray): string {
+   return expression[0];
+}
+
+export function getExpressionText(expression: RegExpMatchArray, trim = true): string {
+   return trim ? expression[1].trim() : expression[1];
+}
+
+export function isExpressionStart(text: string): boolean {
+   return text.trimEnd().endsWith('{{');
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -2,6 +2,7 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 import 'reflect-metadata';
+export * from './expression';
 export * from './glsp/actions';
 export * from './glsp/grid';
 export * from './glsp/id-util';


### PR DESCRIPTION
- Allow specifying expressions in attribute mappings as string
- Validate reference expressions '{{expression}}'
- Provide suggestions for reference expressions
- Allow attribute mappings to have 0 to n sources (previously 1)

Minor:
- Guard return value in selection data service for undefined references