### PR TITLE
Remove duplicate entries for auto-completion suggestions and sort

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -115,12 +115,9 @@
       "name": "Debug All CJS Jest Tests",
       "type": "node",
       "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/jest/bin/jest.js",
-        "--runInBand",
-        "--config=${workspaceRoot}/configs/jest.config.js"
-      ],
+      "cwd": "${workspaceRoot}",
+      "runtimeArgs": ["--inspect-brk", "node_modules/jest/bin/jest.js"],
+      "args": ["--runInBand", "--config=configs/jest.config.js"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     },
@@ -128,13 +125,13 @@
       "name": "Debug All ESM Jest Tests",
       "type": "node",
       "request": "launch",
+      "cwd": "${workspaceRoot}",
       "runtimeArgs": [
         "--experimental-vm-modules",
         "--inspect-brk",
-        "${workspaceRoot}/node_modules/jest/bin/jest.js",
-        "--runInBand",
-        "--config=${workspaceRoot}/configs/esm.jest.config.js"
+        "node_modules/jest/bin/jest.js"
       ],
+      "args": ["--runInBand", "--config=configs/esm.jest.config.js"],
       "env": {
         "NODE_NO_WARNINGS": "1"
       },
@@ -145,13 +142,9 @@
       "name": "Debug Open CJS Jest Test",
       "type": "node",
       "request": "launch",
-      "runtimeArgs": [
-        "--inspect-brk",
-        "${workspaceRoot}/node_modules/jest/bin/jest.js",
-        "--runInBand",
-        "--config=${workspaceRoot}/configs/jest.config.js",
-        "${file}"
-      ],
+      "cwd": "${workspaceRoot}",
+      "runtimeArgs": ["--inspect-brk", "node_modules/jest/bin/jest.js"],
+      "args": ["--runInBand", "--config=configs/jest.config.js", "${fileBasenameNoExtension}"],
       "env": {
         "NODE_NO_WARNINGS": "1"
       },
@@ -162,20 +155,44 @@
       "name": "Debug Open ESM Jest Test",
       "type": "node",
       "request": "launch",
+      "cwd": "${workspaceRoot}",
       "runtimeArgs": [
         "--experimental-vm-modules",
         "--inspect-brk",
-        "${workspaceRoot}/node_modules/jest/bin/jest.js",
+        "node_modules/jest/bin/jest.js"
+      ],
+      "args": ["--runInBand", "--config=configs/esm.jest.config.js", "${fileBasenameNoExtension}"],
+      "env": {
+        "NODE_NO_WARNINGS": "1"
+      },
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "name": "vscode-jest-tests.v2.crossmodel",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "runtimeArgs": [
+        "--experimental-vm-modules",
+        "--inspect-brk",
+        "node_modules/jest/bin/jest.js"
+      ],
+      "args": [
         "--runInBand",
-        "--config=${workspaceRoot}/configs/esm.jest.config.js",
-        "${file}"
+        "--watchAll=false",
+        "--config=configs/esm.jest.config.js",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}"
       ],
       "env": {
         "NODE_NO_WARNINGS": "1"
       },
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "outFiles": []
+      "disableOptimisticBPs": true
     }
   ],
   "compounds": [

--- a/extensions/crossmodel-lang/src/language-server/util/uri-util.ts
+++ b/extensions/crossmodel-lang/src/language-server/util/uri-util.ts
@@ -2,10 +2,8 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 import * as fs from 'fs';
-import * as nodePath from 'path';
+import * as path from 'path';
 import { URI, Utils as UriUtils } from 'vscode-uri';
-
-const posixPath = nodePath.posix || nodePath;
 
 export namespace Utils {
    /**
@@ -24,8 +22,8 @@ export namespace Utils {
       }
       // 3. Handle 'file' scheme separately to account for filesystem specifics
       if (parent.scheme === 'file') {
-         const relative = posixPath.relative(parent.fsPath, child.fsPath);
-         return !!relative && !relative.startsWith('..') && !posixPath.isAbsolute(relative);
+         const relative = path.relative(parent.fsPath, child.fsPath);
+         return !!relative && !relative.startsWith('..') && !path.isAbsolute(relative);
       }
       // 4. Handle other hierarchical schemes
       const childPath = normalizePath(child.path);
@@ -41,7 +39,7 @@ export namespace Utils {
     */
    function normalizePath(toNormalize: string): string {
       // Replace backslashes with forward slashes, normalize and remove trailing slashes
-      return nodePath.posix.normalize(toNormalize.replace(/\\/g, '/')).replace(/\/+$/, '');
+      return path.posix.normalize(toNormalize.replace(/\\/g, '/')).replace(/\/+$/, '');
    }
 
    /**

--- a/extensions/crossmodel-lang/src/language-server/util/uri-util.ts
+++ b/extensions/crossmodel-lang/src/language-server/util/uri-util.ts
@@ -14,8 +14,34 @@ export namespace Utils {
     * @returns true if the child URI is actually a child of the parent URI
     */
    export function isChildOf(parent: URI, child: URI): boolean {
-      const relative = posixPath.relative(parent.fsPath, child.fsPath);
-      return !!relative && !relative.startsWith('..') && !posixPath.isAbsolute(relative);
+      // 1. Schemes and auhorities must match
+      if (parent.scheme !== child.scheme || parent.authority !== child.authority) {
+         return false;
+      }
+      // 2. Both URIs must have hierarchical paths
+      if (!parent.path || !child.path) {
+         return false;
+      }
+      // 3. Handle 'file' scheme separately to account for filesystem specifics
+      if (parent.scheme === 'file') {
+         const relative = posixPath.relative(parent.fsPath, child.fsPath);
+         return !!relative && !relative.startsWith('..') && !posixPath.isAbsolute(relative);
+      }
+      // 4. Handle other hierarchical schemes
+      const childPath = normalizePath(child.path);
+      const parentPath = normalizePath(parent.path);
+      return childPath.startsWith(parentPath + '/');
+   }
+
+   /**
+    * Normalizes a URI path by resolving '.' and '..' segments and removing trailing slashes.
+    * Converts backslashes to forward slashes for consistency.
+    * @param toNormalize The path to normalize.
+    * @returns The normalized path.
+    */
+   function normalizePath(toNormalize: string): string {
+      // Replace backslashes with forward slashes, normalize and remove trailing slashes
+      return nodePath.posix.normalize(toNormalize.replace(/\\/g, '/')).replace(/\/+$/, '');
    }
 
    /**

--- a/extensions/crossmodel-lang/test/language-server/cross-model-completion-provider.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-completion-provider.test.ts
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2024 CrossBreeze.
+ ********************************************************************************/
+
+import { expandToString } from 'langium/generate';
+import { expectCompletion } from 'langium/test';
+import { address } from './test-utils/test-documents/entity/address.js';
+import { customer } from './test-utils/test-documents/entity/customer.js';
+import { order } from './test-utils/test-documents/entity/order.js';
+import { createCrossModelTestServices, MockFileSystem, parseProject, testUri } from './test-utils/utils.js';
+
+const services = createCrossModelTestServices(MockFileSystem);
+const assertCompletion = expectCompletion(services);
+
+describe('CrossModelCompletionProvider', () => {
+   const text = expandToString`
+    relationship:
+       id: Address_Customer
+       name: "Address - Customer"
+       parent: <|>
+    `;
+
+   beforeAll(async () => {
+      const packageA = await parseProject({
+         package: { services, uri: testUri('projectA', 'package.json'), content: { name: 'ProjectA', version: '1.0.0' } },
+         documents: [
+            { services, text: address, documentUri: testUri('projectA', 'address.entity.cm') },
+            { services, text: order, documentUri: testUri('projectA', 'order.entity.cm') }
+         ]
+      });
+
+      await parseProject({
+         package: {
+            services,
+            uri: testUri('projectB', 'package.json'),
+            content: { name: 'ProjectB', version: '1.0.0', dependencies: { ...packageA } }
+         },
+         documents: [{ services, text: customer, documentUri: testUri('projectB', 'customer.entity.cm') }]
+      });
+   });
+
+   test('Completion for entity references in project A', async () => {
+      await assertCompletion({
+         text,
+         parseOptions: { documentUri: testUri('projectA', 'rel.relationship.cm') },
+         index: 0,
+         expectedItems: ['Address', 'Order'],
+         disposeAfterCheck: true
+      });
+   });
+
+   test('Completion for entity references in project B', async () => {
+      await assertCompletion({
+         text,
+         parseOptions: { documentUri: testUri('projectB', 'rel.relationship.cm') },
+         index: 0,
+         expectedItems: ['Customer', 'ProjectA.Address', 'ProjectA.Order'],
+         disposeAfterCheck: true
+      });
+   });
+});

--- a/extensions/crossmodel-lang/test/language-server/cross-model-lang-relationship.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-lang-relationship.test.ts
@@ -22,7 +22,11 @@ const services = createCrossModelTestServices();
 
 describe('CrossModel language Relationship', () => {
    beforeAll(async () => {
-      await parseDocuments(services, [order, customer, address]);
+      await parseDocuments([
+         { services, text: order },
+         { services, text: customer },
+         { services, text: address }
+      ]);
    });
 
    test('Simple file for relationship', async () => {

--- a/extensions/crossmodel-lang/test/language-server/test-utils/utils.ts
+++ b/extensions/crossmodel-lang/test/language-server/test-utils/utils.ts
@@ -2,9 +2,11 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 
-import { EmptyFileSystem, LangiumDocument } from 'langium';
-import { LangiumServices } from 'langium/lsp';
+import { EmptyFileSystem, FileSystemNode, FileSystemProvider, LangiumDocument, URI } from 'langium';
+import { DefaultSharedModuleContext, LangiumServices } from 'langium/lsp';
 import { ParseHelperOptions, parseDocument as langiumParseDocument } from 'langium/test';
+import path from 'path';
+import { PackageJson } from 'type-fest';
 import { CrossModelServices, createCrossModelServices } from '../../../src/language-server/cross-model-module.js';
 import {
    CrossModelRoot,
@@ -19,15 +21,26 @@ import {
 } from '../../../src/language-server/generated/ast.js';
 import { SemanticRoot, TypeGuard, WithDocument, findSemanticRoot } from '../../../src/language-server/util/ast-util.js';
 
-export function createCrossModelTestServices(): CrossModelServices {
-   return createCrossModelServices({ ...EmptyFileSystem }).CrossModel;
+export function createCrossModelTestServices(context: DefaultSharedModuleContext = EmptyFileSystem): CrossModelServices {
+   return createCrossModelServices(context).CrossModel;
 }
 
-export const parseDocument = langiumParseDocument<CrossModelRoot>;
+export interface ProjectInput {
+   package: PackageInput;
+   documents: DocumentInput[];
+}
 
-export interface ParseInput<T = string | string[]> extends ParseHelperOptions {
+export interface PackageInput {
    services: LangiumServices;
-   text: T;
+   uri: string;
+   content: PackageJson & { name: string; version: string };
+}
+
+export type PackageDependency = Record<string, string>;
+
+export interface DocumentInput extends ParseHelperOptions {
+   services: LangiumServices;
+   text: string;
 }
 
 export interface ParseAssert {
@@ -35,20 +48,37 @@ export interface ParseAssert {
    parserErrors?: number;
 }
 
-export async function parseDocuments(
-   services: LangiumServices,
-   inputs: string[],
-   options?: ParseHelperOptions
-): Promise<LangiumDocument<CrossModelRoot>[]> {
-   return Promise.all(inputs.map(input => parseDocument(services, input, options)));
+export async function parseProject(input: ProjectInput): Promise<PackageDependency> {
+   const projectDependency = await parsePackage(input.package);
+   await parseDocuments(input.documents);
+   return projectDependency;
+}
+
+export async function parsePackage(input: PackageInput): Promise<PackageDependency> {
+   await parseDocument({ text: JSON.stringify(input.content), documentUri: input.uri, services: input.services });
+   return { [input.content.name]: input.content.version };
+}
+
+export async function parseDocument(input: DocumentInput): Promise<LangiumDocument<CrossModelRoot>> {
+   if (input.documentUri) {
+      const fileSystemProvider = input.services.shared.workspace.FileSystemProvider;
+      if (fileSystemProvider instanceof MockFileSystemProvider) {
+         fileSystemProvider.setFile(URI.parse(input.documentUri), input.text);
+      }
+   }
+   return langiumParseDocument<CrossModelRoot>(input.services, input.text, input);
+}
+
+export async function parseDocuments(inputs: DocumentInput[]): Promise<LangiumDocument<CrossModelRoot>[]> {
+   return Promise.all(inputs.map(parseDocument));
 }
 
 export async function parseSemanticRoot<T extends SemanticRoot>(
-   input: ParseInput<string>,
+   input: DocumentInput,
    assert: ParseAssert,
    guard: TypeGuard<T>
 ): Promise<WithDocument<T>> {
-   const document = await parseDocument(input.services, input.text, input);
+   const document = await parseDocument(input);
    expect(document.parseResult.lexerErrors).toHaveLength(assert.lexerErrors ?? 0);
    expect(document.parseResult.parserErrors).toHaveLength(assert.parserErrors ?? 0);
    const semanticRoot = findSemanticRoot(document, guard);
@@ -57,18 +87,43 @@ export async function parseSemanticRoot<T extends SemanticRoot>(
    return semanticRoot as WithDocument<T>;
 }
 
-export async function parseEntity(input: ParseInput<string>, assert: ParseAssert = {}): Promise<WithDocument<Entity>> {
+export async function parseEntity(input: DocumentInput, assert: ParseAssert = {}): Promise<WithDocument<Entity>> {
    return parseSemanticRoot(input, assert, isEntity);
 }
 
-export async function parseRelationship(input: ParseInput<string>, assert: ParseAssert = {}): Promise<WithDocument<Relationship>> {
+export async function parseRelationship(input: DocumentInput, assert: ParseAssert = {}): Promise<WithDocument<Relationship>> {
    return parseSemanticRoot(input, assert, isRelationship);
 }
 
-export async function parseSystemDiagram(input: ParseInput<string>, assert: ParseAssert = {}): Promise<WithDocument<SystemDiagram>> {
+export async function parseSystemDiagram(input: DocumentInput, assert: ParseAssert = {}): Promise<WithDocument<SystemDiagram>> {
    return parseSemanticRoot(input, assert, isSystemDiagram);
 }
 
-export async function parseMapping(input: ParseInput<string>, assert: ParseAssert = {}): Promise<WithDocument<Mapping>> {
+export async function parseMapping(input: DocumentInput, assert: ParseAssert = {}): Promise<WithDocument<Mapping>> {
    return parseSemanticRoot(input, assert, isMapping);
+}
+
+export const MockFileSystem: DefaultSharedModuleContext = {
+   fileSystemProvider: () => new MockFileSystemProvider()
+};
+
+export class MockFileSystemProvider implements FileSystemProvider {
+   protected fileContent = new Map<string, string>();
+
+   setFile(uri: URI, content: string): void {
+      this.fileContent.set(uri.toString(), content);
+   }
+
+   async readFile(uri: URI): Promise<string> {
+      return this.fileContent.get(uri.toString()) ?? '';
+   }
+
+   async readDirectory(uri: URI): Promise<FileSystemNode[]> {
+      return [];
+   }
+}
+
+export function testUri(...segments: string[]): string {
+   // making sure the URI works on both Windows and Unix
+   return 'test:///' + path.join(...segments);
 }

--- a/extensions/crossmodel-lang/test/language-server/test-utils/utils.ts
+++ b/extensions/crossmodel-lang/test/language-server/test-utils/utils.ts
@@ -125,5 +125,5 @@ export class MockFileSystemProvider implements FileSystemProvider {
 
 export function testUri(...segments: string[]): string {
    // making sure the URI works on both Windows and Unix
-   return 'test:///' + path.join(...segments);
+   return 'test:///' + path.posix.join(...segments);
 }

--- a/extensions/crossmodel-lang/test/language-server/util/uri-util.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/util/uri-util.test.ts
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (c) 2024 CrossBreeze.
+ ********************************************************************************/
+
+import { URI } from 'vscode-uri';
+import { Utils } from '../../../src/language-server/util/uri-util.js';
+
+describe('Utils', () => {
+   const parentUri = URI.file('/parent');
+   const childUri = URI.file('/parent/child');
+   const unrelatedUri = URI.file('/unrelated');
+
+   describe('isChildOf', () => {
+      test('should return true if child URI is a child of parent URI', () => {
+         expect(Utils.isChildOf(parentUri, childUri)).toBe(true);
+      });
+
+      test('should return false if child URI is not a child of parent URI', () => {
+         expect(Utils.isChildOf(parentUri, unrelatedUri)).toBe(false);
+      });
+
+      test('should return false if URIs have different schemes', () => {
+         expect(Utils.isChildOf(URI.parse('file:///parent'), URI.parse('http://example.com/parent'))).toBe(false);
+      });
+
+      test('should return false if URIs have different authorities', () => {
+         expect(Utils.isChildOf(URI.parse('file:///parent'), URI.parse('file://other/parent'))).toBe(false);
+      });
+
+      test('should return false if URIs do not have hierarchical paths', () => {
+         expect(Utils.isChildOf(URI.parse('file://'), URI.parse('file://'))).toBe(false);
+      });
+   });
+
+   describe('matchSameFolder', () => {
+      const folderProvider = (uri?: URI): URI | undefined => (uri ? URI.file(uri.path.split('/')[1]) : undefined);
+
+      test('should return true if all URIs match the same folder', () => {
+         expect(Utils.matchSameFolder(folderProvider, URI.file('/folder/file1'), URI.file('/folder/file2'))).toBe(true);
+      });
+
+      test('should return false if URIs do not match the same folder', () => {
+         expect(Utils.matchSameFolder(folderProvider, URI.file('/folder/file1'), URI.file('/other/file2'))).toBe(false);
+      });
+
+      test('should return true if no URIs are given', () => {
+         expect(Utils.matchSameFolder(folderProvider)).toBe(true);
+      });
+
+      test('should return true if a single URI is given', () => {
+         expect(Utils.matchSameFolder(folderProvider, URI.file('/folder/file1'))).toBe(true);
+      });
+   });
+});


### PR DESCRIPTION
- Prefer package local names over global names
- Sort local names before global name in textual and diagram editor

Fixes https://github.com/CrossBreezeNL/crossmodel/issues/66