### PR TITLE
Add entity inheritances in the diagram representation

### DIFF
--- a/e2e-tests/src/page-objects/cm-app.ts
+++ b/e2e-tests/src/page-objects/cm-app.ts
@@ -7,6 +7,7 @@ import { TheiaEditor, TheiaNotificationIndicator, TheiaNotificationOverlay, Thei
 import { CMCompositeEditor, IntegratedEditorType } from './cm-composite-editor';
 import { CMExplorerView } from './cm-explorer-view';
 import { CMTheiaIntegration } from './cm-theia-integration';
+import path = require('path');
 
 export interface CMAppArgs extends Omit<IntegrationArgs, 'page'> {
    workspaceUrl?: string;
@@ -18,7 +19,7 @@ export class CMApp extends TheiaGLSPApp {
          { browser: args.browser, page: {} as any, playwright: args.playwright },
          {
             type: 'Theia',
-            workspace: args.workspaceUrl ?? 'src/resources/sample-workspace',
+            workspace: args.workspaceUrl ?? path.join(__dirname, '../resources/sample-workspace'),
             widgetId: '',
             url: args.baseUrl ?? 'http://localhost:3000'
          }

--- a/examples/mapping-example/ExampleDWH/diagrams/ProductInheritance.system-diagram.cm
+++ b/examples/mapping-example/ExampleDWH/diagrams/ProductInheritance.system-diagram.cm
@@ -7,13 +7,13 @@ systemDiagram:
         x: 242
         y: 33
         width: 154.649658203125
-        height: 116
-      - id: ExampleDWH_NewEntityNode
+        height: 116.11013984680176
+      - id: ExampleDWH_DigitalProductNode
         entity: ExampleDWH.DigitalProduct
-        x: 187
+        x: 132
         y: 275
-        width: 154.22557544708252
-        height: 73.93824672698975
+        width: 154.3004560470581
+        height: 96.0881118774414
       - id: PhysicalProductNode
         entity: PhysicalProduct
         x: 429
@@ -22,13 +22,26 @@ systemDiagram:
         height: 136
       - id: PerishableProductNode
         entity: PerishableProduct
-        x: 429
+        x: 583
         y: 495
-        width: 155.22567415237427
-        height: 73.93824672698975
+        width: 183.74362182617188
+        height: 76
       - id: SomeProductNode
         entity: ExampleOtherModel.SomeProduct
-        x: 671
+        x: 682
         y: 352
         width: 207.14583730697632
-        height: 55.33333396911621
+        height: 56.0440559387207
+    edges:
+      - id: ExampleDWH_DigitalProductNodeInheritanceEdge
+        baseNode: ExampleDWH_DigitalProductNode
+        superNode: ExampleDWH_ProductNode
+      - id: PhysicalProductNodeInheritanceEdge
+        baseNode: PhysicalProductNode
+        superNode: ExampleDWH_ProductNode
+      - id: PerishableProductNodeInheritanceEdge
+        baseNode: PerishableProductNode
+        superNode: PhysicalProductNode
+      - id: PerishableProductNodeInheritanceEdge1
+        baseNode: PerishableProductNode
+        superNode: SomeProductNode

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/edge-checker/edge-checker.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/edge-checker/edge-checker.ts
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (c) 2025 CrossBreeze.
+ ********************************************************************************/
+import { INHERITANCE_EDGE_TYPE } from '@crossbreeze/protocol';
+import { EdgeCreationChecker, GModelElement, ModelState, getOrThrow } from '@eclipse-glsp/server';
+import { inject, injectable } from 'inversify';
+import { Entity, EntityNode, isInheritanceEdge } from '../../../language-server/generated/ast.js';
+import { SystemModelState } from '../model/system-model-state.js';
+
+@injectable()
+export class SystemEdgeCreationChecker implements EdgeCreationChecker {
+   @inject(ModelState) protected modelState: SystemModelState;
+
+   isValidSource(edgeType: string, sourceElement: GModelElement): boolean {
+      return true;
+   }
+   isValidTarget(edgeType: string, sourceElement: GModelElement, targetElement: GModelElement): boolean {
+      if (edgeType !== INHERITANCE_EDGE_TYPE) {
+         return true;
+      }
+      const baseEntityNode = getOrThrow(this.modelState.index.findEntityNode(sourceElement.id), 'Base entity node not found');
+      const superEntityNode = getOrThrow(this.modelState.index.findEntityNode(targetElement.id), 'Super entity node not found');
+      if (!baseEntityNode.entity.ref || !superEntityNode.entity.ref) {
+         return false;
+      }
+      // Don't allow creating an inheritance edge if it already exists
+      if (this.hasExistingInheritanceEdge(baseEntityNode, superEntityNode)) {
+         return false;
+      }
+      // Don't allow creating an inheritance edge if it would create a direct circular inheritance
+      if (this.hasSuperEntity(superEntityNode.entity.ref, baseEntityNode.entity.ref)) {
+         return false;
+      }
+
+      // Check if the given superEntity is valid i.e. in  the completion scope of the baseEntity
+      const baseEntityGlobalId = this.modelState.idProvider.getGlobalId(baseEntityNode.entity.ref);
+      const scope = this.modelState.services.language.references.ScopeProvider.getCompletionScope({
+         container: { globalId: baseEntityGlobalId! },
+         property: 'superEntities'
+      });
+
+      const superEntityGlobalId = this.modelState.idProvider.getGlobalId(superEntityNode.entity.ref)!;
+      const isInScope = scope.elementScope.getElement(superEntityNode.entity.ref.id) ?? scope.elementScope.getElement(superEntityGlobalId);
+      if (!isInScope) {
+         return false;
+      }
+      return true;
+   }
+
+   protected hasExistingInheritanceEdge(baseEntityNode: EntityNode, superEntityNode: EntityNode): boolean {
+      const existingInheritanceEdge = this.modelState.systemDiagram.edges.find(edge => {
+         if (!isInheritanceEdge(edge)) {
+            return false;
+         }
+         if (edge.baseNode.ref?.entity.ref === baseEntityNode.entity.ref && edge.superNode.ref?.entity.ref === superEntityNode.entity.ref) {
+            return true;
+         }
+         return false;
+      });
+      return !!existingInheritanceEdge;
+   }
+
+   protected hasSuperEntity(baseEntity: Entity, superEntity: Entity): boolean {
+      return baseEntity.superEntities.some(entity => entity.ref === superEntity);
+   }
+}

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-entity-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-entity-operation-handler.ts
@@ -72,7 +72,8 @@ export class SystemDiagramCreateEntityOperationHandler extends JsonCreateNodeOpe
          id,
          name: id,
          attributes: [],
-         customProperties: []
+         customProperties: [],
+         superEntities: []
       };
 
       const dirName = UriUtils.joinPath(UriUtils.dirname(URI.parse(this.modelState.semanticUri)), '..', 'entities');

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-inheritance-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-inheritance-operation-handler.ts
@@ -1,0 +1,183 @@
+/********************************************************************************
+ * Copyright (c) 2025 CrossBreeze.
+ ********************************************************************************/
+import { INHERITANCE_EDGE_TYPE } from '@crossbreeze/protocol';
+import {
+   ActionDispatcher,
+   Command,
+   CompoundCommand,
+   CreateEdgeOperation,
+   JsonCreateEdgeOperationHandler,
+   MaybePromise,
+   MessageAction,
+   ModelState,
+   SelectAction,
+   getOrThrow
+} from '@eclipse-glsp/server';
+import { inject, injectable } from 'inversify';
+import { CrossModelRoot, Entity, EntityNode, InheritanceEdge, isInheritanceEdge } from '../../../language-server/generated/ast.js';
+import { findDocument } from '../../../language-server/util/ast-util.js';
+import { CrossModelCommand } from '../../common/cross-model-command.js';
+import { SystemModelState } from '../model/system-model-state.js';
+
+@injectable()
+export class SystemDiagramCreateInheritanceOperationHandler extends JsonCreateEdgeOperationHandler {
+   override readonly label = 'Inheritance';
+   readonly elementTypeIds = [INHERITANCE_EDGE_TYPE];
+
+   @inject(ModelState) protected override modelState: SystemModelState;
+   @inject(ActionDispatcher) protected actionDispatcher: ActionDispatcher;
+
+   createCommand(operation: CreateEdgeOperation): MaybePromise<Command | undefined> {
+      const baseEntityNode = getOrThrow(this.modelState.index.findEntityNode(operation.sourceElementId), 'Base entity node not found');
+      const superEntityNode = getOrThrow(this.modelState.index.findEntityNode(operation.targetElementId), 'Super entity node not found');
+      if (!baseEntityNode.entity.ref || !superEntityNode.entity.ref) {
+         return undefined;
+      }
+
+      // If a matching inheritance edge already exists, we don't need to create a new one
+      if (this.hasExistingInheritanceEdge(baseEntityNode, superEntityNode)) {
+         return undefined;
+      }
+
+      if (hasSuperEntity(superEntityNode.entity.ref, baseEntityNode.entity.ref)) {
+         this.actionDispatcher.dispatch(
+            MessageAction.create('Could not create inheritance. Circular inheritance is not allowed.', { severity: 'WARNING' })
+         );
+         return undefined;
+      }
+
+      const diagramCommand = new CrossModelCommand(this.modelState, () => this.createEdge(baseEntityNode, superEntityNode));
+      const existingSemanticInheritance = hasSuperEntity(baseEntityNode.entity.ref, superEntityNode.entity.ref);
+      if (existingSemanticInheritance) {
+         return diagramCommand;
+      }
+
+      // Check if the given superEntity is valid i.e. in  the completion scope of the baseEntity
+      const baseEntityGlobalId = this.modelState.idProvider.getGlobalId(baseEntityNode.entity.ref);
+      const scope = this.modelState.services.language.references.ScopeProvider.getCompletionScope({
+         container: { globalId: baseEntityGlobalId! },
+         property: 'superEntities'
+      });
+
+      const superEntityGlobalId = this.modelState.idProvider.getGlobalId(superEntityNode.entity.ref)!;
+      const isInScope = scope.elementScope.getElement(superEntityNode.entity.ref.id) ?? scope.elementScope.getElement(superEntityGlobalId);
+      if (!isInScope) {
+         return undefined;
+      }
+
+      return new CompoundCommand(new AddInheritanceCommand(this.modelState, operation), diagramCommand);
+   }
+
+   protected hasExistingInheritanceEdge(baseEntityNode: EntityNode, superEntityNode: EntityNode): boolean {
+      const existingInheritanceEdge = this.modelState.systemDiagram.edges.find(edge => {
+         if (!isInheritanceEdge(edge)) {
+            return false;
+         }
+         if (edge.baseNode.ref?.entity.ref === baseEntityNode.entity.ref && edge.superNode.ref?.entity.ref === superEntityNode.entity.ref) {
+            return true;
+         }
+         return false;
+      });
+      return !!existingInheritanceEdge;
+   }
+
+   protected async createEdge(baseEntityNode: EntityNode, superEntityNode: EntityNode): Promise<void> {
+      const edge: InheritanceEdge = {
+         $type: InheritanceEdge,
+         $container: this.modelState.systemDiagram,
+         id: this.modelState.idProvider.findNextId(InheritanceEdge, baseEntityNode.id + 'InheritanceEdge', this.modelState.systemDiagram),
+
+         baseNode: {
+            ref: baseEntityNode,
+            $refText: this.modelState.idProvider.getNodeId(baseEntityNode) || baseEntityNode.id || ''
+         },
+         superNode: {
+            ref: superEntityNode,
+            $refText: this.modelState.idProvider.getNodeId(superEntityNode) || superEntityNode.id || ''
+         },
+         customProperties: []
+      };
+      this.modelState.systemDiagram.edges.push(edge);
+      this.actionDispatcher.dispatchAfterNextUpdate(
+         SelectAction.create({ selectedElementsIDs: [this.modelState.idProvider.getLocalId(edge) ?? edge.id] })
+      );
+   }
+}
+
+export class AddInheritanceCommand implements Command {
+   protected _canUndo = false;
+
+   constructor(
+      protected modelState: SystemModelState,
+      protected operation: CreateEdgeOperation
+   ) {}
+
+   async execute(): Promise<void> {
+      if (this.canUndo()) {
+         return;
+      }
+
+      const baseEntity = this.modelState.index.findEntityNode(this.operation.sourceElementId)?.entity.ref;
+      const superEntity = this.modelState.index.findEntityNode(this.operation.targetElementId)?.entity.ref;
+      if (!baseEntity || !superEntity) {
+         return;
+      }
+      if (hasSuperEntity(baseEntity, superEntity)) {
+         return;
+      }
+
+      baseEntity.superEntities.push({
+         ref: superEntity,
+         $refText: this.modelState.idProvider.getGlobalId(superEntity) || superEntity.id || ''
+      });
+
+      const document = findDocument<CrossModelRoot>(baseEntity)!;
+      await this.modelState.modelService.save({
+         uri: document.uri.toString(),
+         model: document.parseResult.value,
+         clientId: this.modelState.clientId
+      });
+
+      this._canUndo = true;
+   }
+
+   async undo(): Promise<void> {
+      if (!this.canUndo()) {
+         return;
+      }
+
+      const baseEntity = this.modelState.index.findEntityNode(this.operation.sourceElementId)?.entity.ref;
+      const superEntity = this.modelState.index.findEntityNode(this.operation.targetElementId)?.entity.ref;
+      if (!baseEntity || !superEntity) {
+         return;
+      }
+      const index = baseEntity.superEntities.findIndex(entity => entity.ref === superEntity);
+      if (index > -1) {
+         baseEntity.superEntities?.splice(index, 1);
+      }
+      const document = findDocument<CrossModelRoot>(baseEntity)!;
+      await this.modelState.modelService.save({
+         uri: document.uri.toString(),
+         model: document.parseResult.value,
+         clientId: this.modelState.clientId
+      });
+
+      this._canUndo = false;
+   }
+
+   redo(): MaybePromise<void> {
+      if (this.canUndo()) {
+         return;
+      }
+      return this.execute();
+   }
+
+   canUndo(): boolean {
+      return this._canUndo;
+   }
+}
+
+function hasSuperEntity(baseEntity: Entity, superEntity: Entity): boolean {
+   return baseEntity.superEntities.some(entity => entity.ref === superEntity);
+}

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/edges.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/edges.ts
@@ -2,9 +2,15 @@
  * Copyright (c) 2024 CrossBreeze.
  ********************************************************************************/
 
-import { REFERENCE_CONTAINER_TYPE, REFERENCE_PROPERTY, REFERENCE_VALUE, RELATIONSHIP_EDGE_TYPE } from '@crossbreeze/protocol';
+import {
+   INHERITANCE_EDGE_TYPE,
+   REFERENCE_CONTAINER_TYPE,
+   REFERENCE_PROPERTY,
+   REFERENCE_VALUE,
+   RELATIONSHIP_EDGE_TYPE
+} from '@crossbreeze/protocol';
 import { GEdge, GEdgeBuilder } from '@eclipse-glsp/server';
-import { RelationshipEdge } from '../../../language-server/generated/ast.js';
+import { InheritanceEdge, RelationshipEdge } from '../../../language-server/generated/ast.js';
 import { SystemModelIndex } from './system-model-index.js';
 
 export class GRelationshipEdge extends GEdge {
@@ -30,6 +36,28 @@ export class GRelationshipEdgeBuilder extends GEdgeBuilder<GRelationshipEdge> {
       this.sourceId(sourceId || '');
       this.targetId(targetId || '');
 
+      return this;
+   }
+}
+
+export class GInheritanceEdge extends GEdge {
+   override type = INHERITANCE_EDGE_TYPE;
+
+   static override builder(): GInheritanceEdgeBuilder {
+      return new GInheritanceEdgeBuilder(GInheritanceEdge).type(INHERITANCE_EDGE_TYPE);
+   }
+}
+
+export class GInheritanceEdgeBuilder extends GEdgeBuilder<GInheritanceEdge> {
+   set(edge: InheritanceEdge, index: SystemModelIndex): this {
+      this.id(index.createId(edge));
+      this.addCssClasses('diagram-edge', 'inheritance');
+      this.addArg('edgePadding', 5);
+      const sourceId = index.createId(edge.baseNode?.ref);
+      const targetId = index.createId(edge.superNode?.ref);
+
+      this.sourceId(sourceId || '');
+      this.targetId(targetId || '');
       return this;
    }
 }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-diagram-gmodel-factory.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-diagram-gmodel-factory.ts
@@ -3,8 +3,8 @@
  ********************************************************************************/
 import { GEdge, GGraph, GModelFactory, GNode, ModelState } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
-import { EntityNode, RelationshipEdge } from '../../../language-server/generated/ast.js';
-import { GRelationshipEdge } from './edges.js';
+import { EntityNode, InheritanceEdge, RelationshipEdge, isRelationshipEdge } from '../../../language-server/generated/ast.js';
+import { GInheritanceEdge, GRelationshipEdge } from './edges.js';
 import { GEntityNode } from './nodes.js';
 import { SystemModelState } from './system-model-state.js';
 
@@ -33,7 +33,14 @@ export class SystemDiagramGModelFactory implements GModelFactory {
       const graphBuilder = GGraph.builder().id(this.modelState.semanticUri);
 
       diagramRoot.nodes.map(node => this.createEntityNode(node)).forEach(node => graphBuilder.add(node));
-      diagramRoot.edges.map(edge => this.createRelationshipEdge(edge)).forEach(edge => graphBuilder.add(edge));
+      diagramRoot.edges
+         .map(edge => {
+            if (isRelationshipEdge(edge)) {
+               return this.createRelationshipEdge(edge);
+            }
+            return this.createInheritanceEdge(edge);
+         })
+         .forEach(edge => graphBuilder.add(edge));
 
       return graphBuilder.build();
    }
@@ -44,5 +51,9 @@ export class SystemDiagramGModelFactory implements GModelFactory {
 
    protected createRelationshipEdge(edge: RelationshipEdge): GEdge {
       return GRelationshipEdge.builder().set(edge, this.modelState.index).build();
+   }
+
+   protected createInheritanceEdge(edge: InheritanceEdge): GEdge {
+      return GInheritanceEdge.builder().set(edge, this.modelState.index).build();
    }
 }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-model-index.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-model-index.ts
@@ -6,10 +6,12 @@ import { AstNode } from 'langium';
 import {
    Entity,
    EntityNode,
+   InheritanceEdge,
    Relationship,
    RelationshipEdge,
    isEntity,
    isEntityNode,
+   isInheritanceEdge,
    isRelationship,
    isRelationshipEdge
 } from '../../../language-server/generated/ast.js';
@@ -31,6 +33,10 @@ export class SystemModelIndex extends CrossModelIndex {
 
    findRelationshipEdge(id: string): RelationshipEdge | undefined {
       return this.findSemanticElement(id, isRelationshipEdge);
+   }
+
+   findInheritanceEdge(id: string): InheritanceEdge | undefined {
+      return this.findSemanticElement(id, isInheritanceEdge);
    }
 
    protected override indexAstNode(node: AstNode): void {

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-configuration.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-configuration.ts
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
-import { ENTITY_NODE_TYPE, RELATIONSHIP_EDGE_TYPE } from '@crossbreeze/protocol';
+import { ENTITY_NODE_TYPE, INHERITANCE_EDGE_TYPE, RELATIONSHIP_EDGE_TYPE } from '@crossbreeze/protocol';
 import { DiagramConfiguration, ServerLayoutKind, getDefaultMapping } from '@eclipse-glsp/server';
 import { injectable } from 'inversify';
 
@@ -25,6 +25,14 @@ export class SystemDiagramConfiguration implements DiagramConfiguration {
    edgeTypeHints = [
       {
          elementTypeId: RELATIONSHIP_EDGE_TYPE,
+         deletable: true,
+         repositionable: false,
+         routable: false,
+         sourceElementTypeIds: [ENTITY_NODE_TYPE],
+         targetElementTypeIds: [ENTITY_NODE_TYPE]
+      },
+      {
+         elementTypeId: INHERITANCE_EDGE_TYPE,
          deletable: true,
          repositionable: false,
          routable: false,

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-configuration.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-configuration.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 import { ENTITY_NODE_TYPE, INHERITANCE_EDGE_TYPE, RELATIONSHIP_EDGE_TYPE } from '@crossbreeze/protocol';
-import { DiagramConfiguration, ServerLayoutKind, getDefaultMapping } from '@eclipse-glsp/server';
+import { DiagramConfiguration, EdgeTypeHint, ServerLayoutKind, getDefaultMapping } from '@eclipse-glsp/server';
 import { injectable } from 'inversify';
 
 @injectable()
@@ -22,7 +22,7 @@ export class SystemDiagramConfiguration implements DiagramConfiguration {
          resizable: true
       }
    ];
-   edgeTypeHints = [
+   edgeTypeHints: EdgeTypeHint[] = [
       {
          elementTypeId: RELATIONSHIP_EDGE_TYPE,
          deletable: true,
@@ -36,6 +36,7 @@ export class SystemDiagramConfiguration implements DiagramConfiguration {
          deletable: true,
          repositionable: false,
          routable: false,
+         dynamic: true,
          sourceElementTypeIds: [ENTITY_NODE_TYPE],
          targetElementTypeIds: [ENTITY_NODE_TYPE]
       }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-module.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-module.ts
@@ -27,6 +27,7 @@ import { SystemDiagramAddEntityOperationHandler } from './handler/add-entity-ope
 import { SystemDiagramApplyLabelEditOperationHandler } from './handler/apply-edit-operation-handler.js';
 import { SystemDiagramChangeBoundsOperationHandler } from './handler/change-bounds-operation-handler.js';
 import { SystemDiagramCreateEntityOperationHandler } from './handler/create-entity-operation-handler.js';
+import { SystemDiagramCreateInheritanceOperationHandler } from './handler/create-inheritance-operation-handler.js';
 import { SystemDiagramCreateRelationshipOperationHandler } from './handler/create-relationship-operation-handler.js';
 import { SystemDiagramDeleteOperationHandler } from './handler/delete-operation-handler.js';
 import { SystemDiagramDropEntityOperationHandler } from './handler/drop-entity-operation-handler.js';
@@ -64,6 +65,7 @@ export class SystemDiagramModule extends DiagramModule {
       binding.add(SystemDiagramAddEntityOperationHandler);
       binding.add(SystemDiagramCreateEntityOperationHandler);
       binding.add(SystemDiagramApplyLabelEditOperationHandler);
+      binding.add(SystemDiagramCreateInheritanceOperationHandler);
    }
 
    protected override configureContextActionProviders(binding: MultiBinding<ContextActionsProvider>): void {

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-module.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-module.ts
@@ -6,6 +6,7 @@ import {
    ContextActionsProvider,
    DiagramConfiguration,
    DiagramModule,
+   EdgeCreationChecker,
    GModelFactory,
    GModelIndex,
    InstanceMultiBinding,
@@ -23,6 +24,7 @@ import { CrossModelState } from '../common/cross-model-state.js';
 import { CrossModelStorage } from '../common/cross-model-storage.js';
 import { CrossModelSubmissionHandler } from '../common/cross-model-submission-handler.js';
 import { SystemDiagramAddEntityActionProvider } from './command-palette/add-entity-action-provider.js';
+import { SystemEdgeCreationChecker } from './edge-checker/edge-checker.js';
 import { SystemDiagramAddEntityOperationHandler } from './handler/add-entity-operation-handler.js';
 import { SystemDiagramApplyLabelEditOperationHandler } from './handler/apply-edit-operation-handler.js';
 import { SystemDiagramChangeBoundsOperationHandler } from './handler/change-bounds-operation-handler.js';
@@ -89,5 +91,9 @@ export class SystemDiagramModule extends DiagramModule {
 
    protected override bindToolPaletteItemProvider(): BindingTarget<ToolPaletteItemProvider> | undefined {
       return SystemToolPaletteProvider;
+   }
+
+   protected override bindEdgeCreationChecker(): BindingTarget<EdgeCreationChecker> | undefined {
+      return SystemEdgeCreationChecker;
    }
 }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/tool-palette/system-tool-palette-provider.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/tool-palette/system-tool-palette-provider.ts
@@ -3,6 +3,7 @@
  ********************************************************************************/
 import {
    ENTITY_NODE_TYPE,
+   INHERITANCE_EDGE_TYPE,
    ModelStructure,
    RELATIONSHIP_EDGE_TYPE,
    activateDefaultToolsAction,
@@ -62,6 +63,13 @@ export class SystemToolPaletteProvider extends ToolPaletteItemProvider {
                   label: 'Create 1:1 Relationship',
                   icon: ModelStructure.Relationship.ICON,
                   actions: [TriggerEdgeCreationAction.create(RELATIONSHIP_EDGE_TYPE)]
+               },
+               {
+                  id: 'inheritance-create-tool',
+                  sortString: '6',
+                  label: 'Create Inheritance',
+                  icon: 'type-hierarchy-super',
+                  actions: [TriggerEdgeCreationAction.create(INHERITANCE_EDGE_TYPE, { args: { cssClasses: 'diagram-edge inheritance' } })]
                }
             ]
          }

--- a/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
@@ -11,6 +11,7 @@ import {
    AttributeMapping,
    CrossModelAstType,
    Entity,
+   InheritanceEdge,
    isEntity,
    isEntityAttribute,
    isMapping,
@@ -58,6 +59,7 @@ export function registerValidationChecks(services: CrossModelServices): void {
       Mapping: validator.checkMapping,
       Relationship: validator.checkRelationship,
       RelationshipEdge: validator.checkRelationshipEdge,
+      InheritanceEdge: validator.checkInheritanceEdge,
       SourceObject: validator.checkSourceObject,
       SourceObjectCondition: validator.checkSourceObjectCondition,
       SourceObjectDependency: validator.checkSourceObjectDependency,
@@ -226,6 +228,13 @@ export class CrossModelValidator {
       }
       if (edge.targetNode?.ref?.entity?.ref?.$type !== edge.relationship?.ref?.child?.ref?.$type) {
          accept('error', 'Target must match type of child.', { node: edge, property: 'targetNode' });
+      }
+   }
+
+   checkInheritanceEdge(edge: InheritanceEdge, accept: ValidationAcceptor): void {
+      const superEntities = edge.baseNode.ref?.entity.ref?.superEntities ?? [];
+      if (!superEntities.some(entity => entity.ref === edge.superNode.ref?.entity.ref)) {
+         accept('error', 'Base entity must inherit from super entity', { node: edge, property: 'superNode' });
       }
    }
 

--- a/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
@@ -63,7 +63,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@20"
+                "$ref": "#/rules@22"
               },
               "arguments": []
             }
@@ -1175,7 +1175,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@18"
+                        "$ref": "#/rules@19"
                       },
                       "arguments": []
                     }
@@ -1228,7 +1228,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@19"
+                        "$ref": "#/rules@18"
                       },
                       "arguments": []
                     }
@@ -1258,6 +1258,35 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "$type": "RuleCall",
             "rule": {
               "$ref": "#/rules@10"
+            },
+            "arguments": []
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "Edge",
+      "definition": {
+        "$type": "Alternatives",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@20"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@21"
             },
             "arguments": []
           }
@@ -1540,7 +1569,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@18"
+                "$ref": "#/rules@19"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -1567,7 +1596,104 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/rules@18"
+                "$ref": "#/rules@19"
+              },
+              "terminal": {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@3"
+                },
+                "arguments": []
+              },
+              "deprecatedSyntax": false
+            }
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@4"
+            },
+            "arguments": [],
+            "cardinality": "?"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "InheritanceEdge",
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "Keyword",
+            "value": "id"
+          },
+          {
+            "$type": "Keyword",
+            "value": ":"
+          },
+          {
+            "$type": "Assignment",
+            "feature": "id",
+            "operator": "=",
+            "terminal": {
+              "$type": "RuleCall",
+              "rule": {
+                "$ref": "#/rules@14"
+              },
+              "arguments": []
+            }
+          },
+          {
+            "$type": "Keyword",
+            "value": "baseNode"
+          },
+          {
+            "$type": "Keyword",
+            "value": ":"
+          },
+          {
+            "$type": "Assignment",
+            "feature": "baseNode",
+            "operator": "=",
+            "terminal": {
+              "$type": "CrossReference",
+              "type": {
+                "$ref": "#/rules@19"
+              },
+              "terminal": {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@3"
+                },
+                "arguments": []
+              },
+              "deprecatedSyntax": false
+            }
+          },
+          {
+            "$type": "Keyword",
+            "value": "superNode"
+          },
+          {
+            "$type": "Keyword",
+            "value": ":"
+          },
+          {
+            "$type": "Assignment",
+            "feature": "superNode",
+            "operator": "=",
+            "terminal": {
+              "$type": "CrossReference",
+              "type": {
+                "$ref": "#/rules@19"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -1672,7 +1798,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@21"
+                        "$ref": "#/rules@23"
                       },
                       "arguments": []
                     }
@@ -1705,7 +1831,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@28"
+                "$ref": "#/rules@30"
               },
               "arguments": []
             }
@@ -1802,7 +1928,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@22"
+                "$ref": "#/rules@24"
               },
               "arguments": []
             }
@@ -1842,7 +1968,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@23"
+                        "$ref": "#/rules@25"
                       },
                       "arguments": []
                     }
@@ -1895,7 +2021,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@24"
+                        "$ref": "#/rules@26"
                       },
                       "arguments": []
                     }
@@ -2021,7 +2147,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/rules@21"
+            "$ref": "#/rules@23"
           },
           "terminal": {
             "$type": "RuleCall",
@@ -2046,7 +2172,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$ref": "#/rules@25"
+          "$ref": "#/rules@27"
         },
         "arguments": []
       },
@@ -2067,7 +2193,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@26"
+            "$ref": "#/rules@28"
           },
           "arguments": []
         }
@@ -2092,7 +2218,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@27"
+                "$ref": "#/rules@29"
               },
               "arguments": []
             }
@@ -2138,7 +2264,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@27"
+                "$ref": "#/rules@29"
               },
               "arguments": []
             }
@@ -2325,7 +2451,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@29"
+                        "$ref": "#/rules@31"
                       },
                       "arguments": []
                     }
@@ -2433,7 +2559,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@30"
+                "$ref": "#/rules@32"
               },
               "arguments": []
             }
@@ -2473,7 +2599,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@31"
+                        "$ref": "#/rules@33"
                       },
                       "arguments": []
                     }

--- a/extensions/crossmodel-lang/src/language-server/system-diagram.langium
+++ b/extensions/crossmodel-lang/src/language-server/system-diagram.langium
@@ -16,11 +16,15 @@ SystemDiagram:
         )?
         ('edges' ':'
             INDENT 
-                (LIST_ITEM edges+=RelationshipEdge)+
+                (LIST_ITEM edges+=Edge)+
             DEDENT
         )?
         CustomProperties?
     DEDENT
+;
+
+Edge:
+    RelationshipEdge | InheritanceEdge
 ;
 
 
@@ -44,5 +48,12 @@ RelationshipEdge:
     'relationship' ':' relationship=[Relationship:IDReference]
     'sourceNode' ':' sourceNode=[EntityNode:IDReference]
     'targetNode' ':' targetNode=[EntityNode:IDReference]
+    CustomProperties?
+;
+
+InheritanceEdge:
+    'id' ':' id=ID
+    'baseNode' ':' baseNode=[EntityNode:IDReference]
+    'superNode' ':' superNode=[EntityNode:IDReference]
     CustomProperties?
 ;

--- a/extensions/crossmodel-lang/syntaxes/cross-model.tmLanguage.json
+++ b/extensions/crossmodel-lang/syntaxes/cross-model.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.cross-model",
-      "match": "\\b(TRUE|apply|attribute|attributes|child|conditions|cross-join|customProperties|datatype|dependencies|description|diagram|edges|entity|expression|from|height|id|identifier|inherits|inner-join|join|left-join|mapping|mappings|name|nodes|parent|relationship|sourceNode|sources|systemDiagram|target|targetNode|true|type|value|width|x|y)\\b"
+      "match": "\\b(TRUE|apply|attribute|attributes|baseNode|child|conditions|cross-join|customProperties|datatype|dependencies|description|diagram|edges|entity|expression|from|height|id|identifier|inherits|inner-join|join|left-join|mapping|mappings|name|nodes|parent|relationship|sourceNode|sources|superNode|systemDiagram|target|targetNode|true|type|value|width|x|y)\\b"
     },
     {
       "name": "string.quoted.double.cross-model",

--- a/extensions/crossmodel-lang/test/language-server/cross-model-lang-diagram.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-lang-diagram.test.ts
@@ -92,7 +92,7 @@ describe('CrossModel language Diagram', () => {
          expect(edge1?.relationship?.$refText).toBe('Order_Customer');
       });
 
-      describe('Diagram with with nodes and inheritance edges', () => {
+      describe('Diagram with nodes and inheritance edges', () => {
          test('Simple file for diagram and inheritance edges', async () => {
             const systemDiagram = await parseSystemDiagram({ services, text: diagram7 });
 

--- a/extensions/crossmodel-lang/test/language-server/cross-model-lang-diagram.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-lang-diagram.test.ts
@@ -4,7 +4,8 @@
 import { describe, expect, test } from '@jest/globals';
 import { isReference } from 'langium';
 
-import { diagram1, diagram2, diagram3, diagram4, diagram5, diagram6 } from './test-utils/test-documents/diagram/index.js';
+import { InheritanceEdge, RelationshipEdge, isInheritanceEdge, isRelationshipEdge } from '../../src/language-server/generated/ast.js';
+import { diagram1, diagram2, diagram3, diagram4, diagram5, diagram6, diagram7 } from './test-utils/test-documents/diagram/index.js';
 import { createCrossModelTestServices, parseSystemDiagram } from './test-utils/utils.js';
 
 const services = createCrossModelTestServices();
@@ -34,20 +35,21 @@ describe('CrossModel language Diagram', () => {
       });
    });
 
-   describe('Diagram with edges', () => {
-      test('Simple file for diagram and edges', async () => {
+   describe('Diagram with relationship edges', () => {
+      test('Simple file for diagram and relationship edges', async () => {
          const systemDiagram = await parseSystemDiagram({ services, text: diagram3 });
 
          expect(systemDiagram?.edges).toHaveLength(1);
-         const edge1 = systemDiagram?.edges[0];
+         const edge1 = systemDiagram?.edges[0] as RelationshipEdge;
+         expect(isRelationshipEdge(edge1)).toBe(true);
          expect(edge1?.id).toBe('OrderCustomerEdge');
          expect(isReference(edge1?.relationship)).toBe(true);
          expect(edge1?.relationship?.$refText).toBe('Order_Customer');
       });
    });
 
-   describe('Diagram with nodes and edges', () => {
-      test('Simple file for diagram and edges', async () => {
+   describe('Diagram with nodes and relationship edges', () => {
+      test('Simple file for diagram and relationship edges', async () => {
          const systemDiagram = await parseSystemDiagram({ services, text: diagram5 });
 
          expect(systemDiagram?.name).toBe('System diagram 1');
@@ -61,13 +63,14 @@ describe('CrossModel language Diagram', () => {
          expect(node1?.x).toBe(100);
 
          expect(systemDiagram?.edges).toHaveLength(1);
-         const edge1 = systemDiagram?.edges[0];
+         const edge1 = systemDiagram?.edges[0] as RelationshipEdge;
+         expect(isRelationshipEdge(edge1)).toBe(true);
          expect(edge1?.id).toBe('OrderCustomerEdge');
          expect(isReference(edge1?.relationship)).toBe(true);
          expect(edge1?.relationship?.$refText).toBe('Order_Customer');
       });
 
-      test('Simple file for diagram and edges, but description and name coming last', async () => {
+      test('Simple file for diagram and relationship edges, but description and name coming last', async () => {
          const systemDiagram = await parseSystemDiagram({ services, text: diagram6 }, { parserErrors: 3 });
 
          const node1 = systemDiagram?.nodes[0];
@@ -82,10 +85,40 @@ describe('CrossModel language Diagram', () => {
          expect(node1?.x).toBe(100);
 
          expect(systemDiagram?.edges).toHaveLength(1);
-         const edge1 = systemDiagram?.edges[0];
+         const edge1 = systemDiagram?.edges[0] as RelationshipEdge;
+         expect(isRelationshipEdge(edge1)).toBe(true);
          expect(edge1?.id).toBe('OrderCustomerEdge');
          expect(isReference(edge1?.relationship)).toBe(true);
          expect(edge1?.relationship?.$refText).toBe('Order_Customer');
+      });
+
+      describe('Diagram with with nodes and inheritance edges', () => {
+         test('Simple file for diagram and inheritance edges', async () => {
+            const systemDiagram = await parseSystemDiagram({ services, text: diagram7 });
+
+            expect(systemDiagram?.nodes).toHaveLength(2);
+
+            const node1 = systemDiagram?.nodes[0];
+            expect(node1?.id).toBe('CustomerNode');
+            expect(isReference(node1?.entity)).toBe(true);
+            expect(node1?.entity?.$refText).toBe('Customer');
+            expect(node1?.x).toBe(100);
+
+            const node2 = systemDiagram?.nodes[1];
+            expect(node2?.id).toBe('SubCustomerNode');
+            expect(isReference(node2?.entity)).toBe(true);
+            expect(node2?.entity?.$refText).toBe('SubCustomer');
+            expect(node2?.x).toBe(400);
+
+            expect(systemDiagram?.edges).toHaveLength(1);
+            const edge1 = systemDiagram?.edges[0] as InheritanceEdge;
+            expect(isInheritanceEdge(edge1)).toBe(true);
+            expect(edge1?.id).toBe('SubCustomerInheritanceEdge');
+            expect(isReference(edge1?.baseNode)).toBe(true);
+            expect(edge1?.baseNode?.$refText).toBe('SubCustomerNode');
+            expect(isReference(edge1?.superNode)).toBe(true);
+            expect(edge1?.superNode?.$refText).toBe('CustomerNode');
+         });
       });
    });
 });

--- a/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/diagram/diagram7.ts
+++ b/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/diagram/diagram7.ts
@@ -1,0 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2025 CrossBreeze.
+ ********************************************************************************/
+export const diagram7 = `systemDiagram:
+    id: Systemdiagram1
+    nodes:
+      - id: CustomerNode
+        entity: Customer
+        x: 100
+        y: 100
+        width: 100
+        height: 100
+      - id: SubCustomerNode
+        entity: SubCustomer
+        x: 400
+        y: 150
+        width: 100
+        height: 100
+    edges:
+      - id: SubCustomerInheritanceEdge
+        baseNode: SubCustomerNode
+        superNode: CustomerNode`;

--- a/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/diagram/index.ts
+++ b/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/diagram/index.ts
@@ -7,3 +7,4 @@ export * from './diagram3.js';
 export * from './diagram4.js';
 export * from './diagram5.js';
 export * from './diagram6.js';
+export * from './diagram7.js';

--- a/extensions/crossmodel-lang/tsconfig.json
+++ b/extensions/crossmodel-lang/tsconfig.json
@@ -6,6 +6,8 @@
     "sourceMap": true,
     "outDir": "out",
     "strict": true,
+    "strictPropertyInitialization": false,
+    "useDefineForClassFields": false,
     "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noImplicitOverride": true,

--- a/packages/glsp-client/src/browser/system-diagram/edge-creation-tool/system-edge-creation-tool.ts
+++ b/packages/glsp-client/src/browser/system-diagram/edge-creation-tool/system-edge-creation-tool.ts
@@ -9,24 +9,25 @@ import {
    CursorCSS,
    Disposable,
    DragAwareMouseListener,
+   DrawFeedbackEdgeAction,
    EdgeCreationTool,
    FeedbackEmitter,
    GEdge,
+   GEdgeSchema,
    GModelElement,
    HoverFeedbackAction,
    IActionDispatcher,
    ITypeHintProvider,
    ModifyCSSFeedbackAction,
    Point,
+   RemoveFeedbackEdgeAction,
    TriggerEdgeCreationAction,
    cursorFeedbackAction,
+   defaultFeedbackEdgeSchema,
    findParentByFeature,
    isConnectable
 } from '@eclipse-glsp/client';
-import {
-   DrawFeedbackEdgeAction,
-   RemoveFeedbackEdgeAction
-} from '@eclipse-glsp/client/lib/features/tools/edge-creation/dangling-edge-feedback';
+
 import { injectable } from '@theia/core/shared/inversify';
 
 const CSS_EDGE_CREATION = 'edge-creation';
@@ -105,9 +106,17 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
          if (dragDistance > 3) {
             // assign source if possible
             this.source = this.dragContext.element.id;
+            let edgeSchema: Partial<GEdgeSchema> | undefined = undefined;
+            // add css classes to the edge if specified in trigger action
+            if (this.triggerAction.args?.cssClasses) {
+               const cssClasses = this.triggerAction.args?.cssClasses.toString().split(' ');
+               defaultFeedbackEdgeSchema.cssClasses?.forEach(cssClass => cssClasses.push(cssClass));
+               edgeSchema = { cssClasses };
+            }
+
             this.feedbackEdgeFeedback
                .add(
-                  DrawFeedbackEdgeAction.create({ elementTypeId: this.triggerAction.elementTypeId, sourceId: this.source }),
+                  DrawFeedbackEdgeAction.create({ elementTypeId: this.triggerAction.elementTypeId, sourceId: this.source, edgeSchema }),
                   RemoveFeedbackEdgeAction.create()
                )
                .submit();

--- a/packages/glsp-client/src/browser/system-diagram/edge-creation-tool/system-edge-creation-tool.ts
+++ b/packages/glsp-client/src/browser/system-diagram/edge-creation-tool/system-edge-creation-tool.ts
@@ -4,6 +4,8 @@
 
 import {
    Action,
+   AnchorComputerRegistry,
+   Bounds,
    Connectable,
    CreateEdgeOperation,
    CursorCSS,
@@ -11,37 +13,63 @@ import {
    DragAwareMouseListener,
    DrawFeedbackEdgeAction,
    EdgeCreationTool,
+   FeedbackEdgeEnd,
+   FeedbackEdgeEndMovingMouseListener,
    FeedbackEmitter,
+   GConnectableElement,
    GEdge,
    GEdgeSchema,
+   GGraph,
    GModelElement,
    HoverFeedbackAction,
    IActionDispatcher,
+   IFeedbackActionDispatcher,
    ITypeHintProvider,
    ModifyCSSFeedbackAction,
+   MoveAction,
    Point,
    RemoveFeedbackEdgeAction,
+   RequestCheckEdgeAction,
    TriggerEdgeCreationAction,
    cursorFeedbackAction,
    defaultFeedbackEdgeSchema,
+   feedbackEdgeEndId,
    findParentByFeature,
-   isConnectable
+   getAbsolutePosition,
+   isBoundsAware,
+   isConnectable,
+   toAbsoluteBounds
 } from '@eclipse-glsp/client';
 
 import { injectable } from '@theia/core/shared/inversify';
 
 const CSS_EDGE_CREATION = 'edge-creation';
+const CSS_SOURCE_HIGHLIGHT = 'source-highlight';
 
 @injectable()
 export class SystemEdgeCreationTool extends EdgeCreationTool {
+   protected creationMouseListener: SystemEdgeCreationToolMouseListener;
+
    protected override creationListener(): void {
-      const creationListener = new SystemEdgeCreationToolMouseListener(
+      this.creationMouseListener = new SystemEdgeCreationToolMouseListener(
          this.triggerAction,
          this.actionDispatcher,
          this.typeHintProvider,
          this
       );
-      this.toDisposeOnDisable.push(creationListener, this.mouseTool.registerListener(creationListener));
+      this.toDisposeOnDisable.push(this.creationMouseListener, this.mouseTool.registerListener(this.creationMouseListener));
+   }
+
+   override trackFeedbackEdge(): void {
+      const mouseMovingFeedback = new SystemFeedbackEndMover(this.anchorRegistry, this.feedbackDispatcher, this.creationMouseListener);
+      this.toDisposeOnDisable.push(mouseMovingFeedback, this.mouseTool.registerListener(mouseMovingFeedback));
+   }
+
+   protected override toolFeedback(): void {
+      const toolFeedback = this.createFeedbackEmitter()
+         .add(ModifyCSSFeedbackAction.create({ add: [CSS_EDGE_CREATION] }), ModifyCSSFeedbackAction.create({ remove: [CSS_EDGE_CREATION] }))
+         .submit();
+      this.toDisposeOnDisable.push(toolFeedback);
    }
 }
 
@@ -55,6 +83,39 @@ export interface DragConnectionContext {
    dragStart: Point;
 }
 
+export class SystemFeedbackEndMover extends FeedbackEdgeEndMovingMouseListener {
+   constructor(
+      anchorRegistry: AnchorComputerRegistry,
+      feedbackDispatcher: IFeedbackActionDispatcher,
+      protected creationListener: SystemEdgeCreationToolMouseListener
+   ) {
+      super(anchorRegistry, feedbackDispatcher);
+   }
+
+   // Override and use the connection context of the creation mouse listener to only snap to valid targets
+   override mouseMove(target: GModelElement, event: MouseEvent): Action[] {
+      const root = target.root;
+      const edgeEnd = root.index.getById(feedbackEdgeEndId(root));
+      if (!(edgeEnd instanceof FeedbackEdgeEnd) || !edgeEnd.feedbackEdge) {
+         return [];
+      }
+
+      const edge = edgeEnd.feedbackEdge;
+      const position = getAbsolutePosition(edgeEnd, event);
+      const context = this.creationListener.currentConnectionContext;
+      if (context && context.element instanceof GConnectableElement && context.canConnect && edge.source && isBoundsAware(edge.source)) {
+         const anchor = this.computeAbsoluteAnchor(context.element, Bounds.center(toAbsoluteBounds(edge.source)));
+         if (Point.euclideanDistance(anchor, edgeEnd.position) > 1) {
+            this.feedback.add(MoveAction.create([{ elementId: edgeEnd.id, toPosition: anchor }], { animate: false })).submit();
+         }
+      } else {
+         this.feedback.add(MoveAction.create([{ elementId: edgeEnd.id, toPosition: position }], { animate: false })).submit();
+      }
+
+      return [];
+   }
+}
+
 export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener implements Disposable {
    protected source?: string;
    protected target?: string;
@@ -64,6 +125,8 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
    protected mouseMoveFeedback: FeedbackEmitter;
    protected sourceFeedback: FeedbackEmitter;
    protected feedbackEdgeFeedback: FeedbackEmitter;
+   protected connectionContext?: ConnectionContext;
+   protected pendingDynamicCheck = false;
 
    constructor(
       protected triggerAction: TriggerEdgeCreationAction,
@@ -79,6 +142,10 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
       this.sourceFeedback = tool.createFeedbackEmitter();
    }
 
+   get currentConnectionContext(): ConnectionContext | undefined {
+      return this.connectionContext;
+   }
+
    protected isSourceSelected(): boolean {
       return this.source !== undefined;
    }
@@ -91,7 +158,7 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
       const result = super.mouseDown(target, event);
       if (event.button === 0 && !this.isSourceSelected()) {
          // update the current target
-         const context = this.calculateContext(target, event);
+         const context = this.calculateNewContext(target, true);
          if (context.element && context.canConnect) {
             this.dragContext = { element: context.element, dragStart: { x: event.clientX, y: event.clientY } };
          }
@@ -121,17 +188,26 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
                )
                .submit();
 
+            // source element feedback
+            if (this.isSourceSelected()) {
+               this.sourceFeedback
+                  .add(
+                     ModifyCSSFeedbackAction.create({ elements: [this.source], add: [CSS_SOURCE_HIGHLIGHT] }),
+                     ModifyCSSFeedbackAction.create({ elements: [this.source], remove: [CSS_SOURCE_HIGHLIGHT] })
+                  )
+                  .submit();
+            }
             this.dragContext = undefined;
          }
       }
-      this.updateFeedback(target, event);
+      this.updateFeedback(target);
       return result;
    }
 
    override draggingMouseUp(target: GModelElement, event: MouseEvent): Action[] {
       const result = super.draggingMouseUp(target, event);
       if (this.isSourceSelected()) {
-         const context = this.calculateContext(target, event);
+         const context = this.calculateNewContext(target, true);
          if (context.element && context.canConnect) {
             this.target = context.element.id;
             result.push(
@@ -145,49 +221,70 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
          }
       }
       this.dispose();
-      this.updateFeedback(target, event);
+      this.updateFeedback(target);
       return result;
    }
 
    override nonDraggingMouseUp(element: GModelElement, event: MouseEvent): Action[] {
       this.dispose();
-      this.updateFeedback(element, event);
+      this.updateFeedback(element);
       return [];
    }
 
    protected canConnect(element: GModelElement | undefined, role: 'source' | 'target'): boolean {
-      return (
-         !!element &&
-         !!isConnectable(element) &&
-         element.canConnect(this.proxyEdge, role) &&
-         (role !== 'target' || this.source !== element?.id)
-      );
+      if (
+         !element ||
+         !isConnectable(element) ||
+         !element.canConnect(this.proxyEdge, role) ||
+         (role === 'target' && this.source === element.id)
+      ) {
+         return false;
+      }
+      if (!this.isDynamic(this.proxyEdge.type)) {
+         return true;
+      }
+      const sourceElement = this.source ?? element;
+      const targetElement = this.source ? element : undefined;
+
+      this.pendingDynamicCheck = true;
+      // Request server edge check
+      this.actionDispatcher
+         .request(RequestCheckEdgeAction.create({ sourceElement, targetElement, edgeType: this.proxyEdge.type }))
+         .then(result => {
+            if (this.pendingDynamicCheck) {
+               this.connectionContext = { canConnect: result.isValid, element };
+               this.pendingDynamicCheck = false;
+               this.updateFeedback(element, true);
+            }
+         })
+         .catch(err => console.error('Dynamic edge check failed with: ', err));
+      // Temporarily mark the target as invalid while we wait for the server response,
+      return false;
    }
 
-   protected updateFeedback(target: GModelElement, event: MouseEvent): void {
-      const context = this.calculateContext(target, event);
+   protected isDynamic(edgeTypeId: string): boolean {
+      const typeHint = this.typeHintProvider.getEdgeTypeHint(edgeTypeId);
+      return typeHint?.dynamic ?? false;
+   }
 
-      // source element feedback
-      if (this.isSourceSelected()) {
-         this.sourceFeedback
-            .add(
-               HoverFeedbackAction.create({ mouseoverElement: this.source!, mouseIsOver: true }),
-               HoverFeedbackAction.create({ mouseoverElement: this.source!, mouseIsOver: false })
-            )
-            .submit();
-      }
-
-      // cursor feedback
-      if (!context.element || context.element?.id === this.source) {
-         // by default we want to use the edge creation CSS when the tool is active
-         this.registerFeedback(
-            [ModifyCSSFeedbackAction.create({ add: [CSS_EDGE_CREATION] })],
-            [ModifyCSSFeedbackAction.create({ remove: [CSS_EDGE_CREATION] })]
-         );
+   protected updateFeedback(target: GModelElement, forceUpdate?: boolean): void {
+      const context = this.calculateNewContext(target, forceUpdate ? true : undefined);
+      if (!context) {
          return;
       }
 
-      if (!context.canConnect) {
+      if (this.pendingDynamicCheck) {
+         return;
+      }
+
+      // cursor feedback
+      // if the context is invalid or the target is the root graph we show the default cursor
+      if (!context.element || target instanceof GGraph) {
+         this.registerFeedback([cursorFeedbackAction()]);
+         return;
+      }
+
+      if (this.isSourceSelected() && !context.canConnect) {
          this.registerFeedback([cursorFeedbackAction(CursorCSS.OPERATION_NOT_ALLOWED)], [cursorFeedbackAction()]);
          return;
       }
@@ -208,12 +305,23 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
       this.mouseMoveFeedback.submit();
    }
 
-   protected calculateContext(target: GModelElement, event: MouseEvent, previousContext?: ConnectionContext): ConnectionContext {
+   /**
+    * Recalculates the connection context based on the current target element and the event.
+    * @returns the new connection context or the current context if the context did not change
+    */
+   protected calculateNewContext(target: GModelElement, returnCurrent: true): ConnectionContext;
+   /**
+    * Recalculates the connection context based on the current target element and the event.
+    * @returns the new connection context or undefined if the context did not change
+    */
+   protected calculateNewContext(target: GModelElement, returnCurrent?: boolean): ConnectionContext | undefined;
+   protected calculateNewContext(target: GModelElement, returnCurrent?: boolean): ConnectionContext | undefined {
       const context: ConnectionContext = {};
       context.element = findParentByFeature(target, isConnectable);
-      if (previousContext && previousContext.element === context.element) {
-         return previousContext;
+      if (this.connectionContext && this.connectionContext.element === context.element) {
+         return returnCurrent ? this.connectionContext : undefined;
       }
+      this.pendingDynamicCheck = false;
       if (!this.isSourceSelected()) {
          context.canConnect = this.canConnect(context.element, 'source');
       } else if (!this.isTargetSelected()) {
@@ -221,6 +329,7 @@ export class SystemEdgeCreationToolMouseListener extends DragAwareMouseListener 
       } else {
          context.canConnect = false;
       }
+      this.connectionContext = context;
       return context;
    }
 

--- a/packages/glsp-client/src/browser/system-diagram/hover/hover-listener.ts
+++ b/packages/glsp-client/src/browser/system-diagram/hover/hover-listener.ts
@@ -1,0 +1,21 @@
+/********************************************************************************
+ * Copyright (c) 2025 CrossBreeze.
+ ********************************************************************************/
+
+import { Action, FocusStateChangedAction, GlspHoverMouseListener, HoverFeedbackAction, ICommand } from '@eclipse-glsp/client';
+import { injectable } from '@theia/core/shared/inversify';
+
+@injectable()
+export class SystemHoverListener extends GlspHoverMouseListener {
+   // Override handle method to prevent deactivation of hover feedback when the edge edit tool is enabled
+   override handle(action: Action): void | Action | ICommand {
+      if (FocusStateChangedAction.is(action) && !action.hasFocus) {
+         this.stopMouseOverTimer();
+         if (this.lastHoverFeedbackElementId) {
+            const previousTargetId = this.lastHoverFeedbackElementId;
+            this.lastHoverFeedbackElementId = undefined;
+            return HoverFeedbackAction.create({ mouseoverElement: previousTargetId, mouseIsOver: false });
+         }
+      }
+   }
+}

--- a/packages/glsp-client/src/browser/system-diagram/hover/hover-module.ts
+++ b/packages/glsp-client/src/browser/system-diagram/hover/hover-module.ts
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2025 CrossBreeze.
+ ********************************************************************************/
+
+import { FeatureModule, GlspHoverMouseListener, hoverModule } from '@eclipse-glsp/client';
+import { SystemHoverListener } from './hover-listener';
+
+export const systemHoverModule = new FeatureModule(
+   (bind, unbind, isBound, rebind) => {
+      bind(SystemHoverListener).toSelf().inSingletonScope();
+      rebind(GlspHoverMouseListener).toService(SystemHoverListener);
+   },
+   { featureId: Symbol('system-hover'), requires: hoverModule }
+);

--- a/packages/glsp-client/src/browser/system-diagram/model.ts
+++ b/packages/glsp-client/src/browser/system-diagram/model.ts
@@ -26,6 +26,8 @@ export class EntityNode extends RectangularNode implements WithEditableLabel {
 
 export class RelationshipEdge extends GEdge {}
 
+export class InheritanceEdge extends GEdge {}
+
 export class GEditableLabel extends GLabel implements EditableLabel {
    editControlPositionCorrection = {
       x: -9,

--- a/packages/glsp-client/src/browser/system-diagram/system-diagram-configuration.ts
+++ b/packages/glsp-client/src/browser/system-diagram/system-diagram-configuration.ts
@@ -1,15 +1,24 @@
 /********************************************************************************
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
-import { ATTRIBUTE_COMPARTMENT_TYPE, ENTITY_NODE_TYPE, LABEL_ENTITY, RELATIONSHIP_EDGE_TYPE } from '@crossbreeze/protocol';
+import {
+   ATTRIBUTE_COMPARTMENT_TYPE,
+   ENTITY_NODE_TYPE,
+   INHERITANCE_EDGE_TYPE,
+   LABEL_ENTITY,
+   RELATIONSHIP_EDGE_TYPE
+} from '@crossbreeze/protocol';
 import {
    ContainerConfiguration,
+   DefaultTypes,
+   GGraph,
    GLabelView,
    configureDefaultModelElements,
    configureModelElement,
    editLabelFeature,
    gridModule,
    initializeDiagramContainer,
+   overrideModelElement,
    withEditLabelFeature
 } from '@eclipse-glsp/client';
 import { GLSPDiagramConfiguration } from '@eclipse-glsp/theia-integration';
@@ -19,10 +28,10 @@ import { createCrossModelDiagramModule } from '../crossmodel-diagram-module';
 import { AttributeCompartment } from '../model';
 import { AttributeCompartmentView } from '../views';
 import { systemEdgeCreationToolModule } from './edge-creation-tool/edge-creation-tool-module';
-import { EntityNode, GEditableLabel, RelationshipEdge } from './model';
+import { EntityNode, GEditableLabel, InheritanceEdge, RelationshipEdge } from './model';
 import { systemNodeCreationModule } from './node-creation-tool/node-creation-tool-module';
 import { systemSelectModule } from './select-tool/select-tool-module';
-import { EntityNodeView, RelationshipEdgeView } from './views';
+import { EntityNodeView, InheritanceEdgeView, RelationshipEdgeView, SystemGraphView } from './views';
 
 export class SystemDiagramConfiguration extends GLSPDiagramConfiguration {
    diagramType: string = SystemDiagramLanguage.diagramType;
@@ -53,8 +62,10 @@ const systemDiagramModule = createCrossModelDiagramModule((bind, unbind, isBound
    // The glsp-server can send a request to render a specific view given a type, e.g. node:entity
    // The model class holds the client-side model and properties
    // The view class shows how to draw the svg element given the properties of the model class
+   overrideModelElement(context, DefaultTypes.GRAPH, GGraph, SystemGraphView);
    configureModelElement(context, ENTITY_NODE_TYPE, EntityNode, EntityNodeView, { enable: [withEditLabelFeature] });
    configureModelElement(context, RELATIONSHIP_EDGE_TYPE, RelationshipEdge, RelationshipEdgeView);
    configureModelElement(context, ATTRIBUTE_COMPARTMENT_TYPE, AttributeCompartment, AttributeCompartmentView);
    configureModelElement(context, LABEL_ENTITY, GEditableLabel, GLabelView, { enable: [editLabelFeature] });
+   configureModelElement(context, INHERITANCE_EDGE_TYPE, InheritanceEdge, InheritanceEdgeView);
 });

--- a/packages/glsp-client/src/browser/system-diagram/system-diagram-configuration.ts
+++ b/packages/glsp-client/src/browser/system-diagram/system-diagram-configuration.ts
@@ -28,6 +28,7 @@ import { createCrossModelDiagramModule } from '../crossmodel-diagram-module';
 import { AttributeCompartment } from '../model';
 import { AttributeCompartmentView } from '../views';
 import { systemEdgeCreationToolModule } from './edge-creation-tool/edge-creation-tool-module';
+import { systemHoverModule } from './hover/hover-module';
 import { EntityNode, GEditableLabel, InheritanceEdge, RelationshipEdge } from './model';
 import { systemNodeCreationModule } from './node-creation-tool/node-creation-tool-module';
 import { systemSelectModule } from './select-tool/select-tool-module';
@@ -43,6 +44,7 @@ export class SystemDiagramConfiguration extends GLSPDiagramConfiguration {
             replace: systemSelectModule
          },
          ...containerConfiguration,
+         systemHoverModule,
          gridModule,
          systemDiagramModule,
          systemNodeCreationModule,

--- a/packages/glsp-client/src/browser/system-diagram/views.tsx
+++ b/packages/glsp-client/src/browser/system-diagram/views.tsx
@@ -1,9 +1,14 @@
 /********************************************************************************
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
-
-import { GEdgeView } from '@eclipse-glsp/client';
+/** @jsx svg */
+/* eslint-disable react/no-unknown-property */
+/* eslint-disable react/jsx-key */
+import { GEdgeView, GGraph, GGraphView, RenderingContext, TYPES, ViewerOptions, svg } from '@eclipse-glsp/client';
+import { inject } from '@theia/core/shared/inversify';
 import { injectable } from 'inversify';
+import { ReactNode } from 'react';
+import { VNode, VNodeStyle } from 'snabbdom';
 import { DiagramNodeView } from '../views';
 
 @injectable()
@@ -11,3 +16,74 @@ export class EntityNodeView extends DiagramNodeView {}
 
 @injectable()
 export class RelationshipEdgeView extends GEdgeView {}
+
+@injectable()
+export class InheritanceEdgeView extends GEdgeView {}
+
+const MARKER_INHERITANCE_ID = 'marker-inheritance';
+const MARKER_INHERITANCE_SELECTED_ID = 'marker-inheritance-selected';
+export class SystemGraphView extends GGraphView {
+   @inject(TYPES.ViewerOptions) protected viewerOptions: ViewerOptions;
+
+   protected createDefId(id: string): string {
+      return `${this.viewerOptions.baseDiv}__svg__def__${id}`;
+   }
+
+   override render(model: Readonly<GGraph>, context: RenderingContext): VNode {
+      const edgeRouting = this.edgeRouterRegistry.routeAllChildren(model);
+      const transform = `scale(${model.zoom}) translate(${-model.scroll.x},${-model.scroll.y})`;
+      const graph: any = (
+         <svg class-sprotty-graph={true}>
+            <g transform={transform}>
+               {this.renderAdditionals(context) as ReactNode}
+               {context.renderChildren(model, { edgeRouting }) as ReactNode}
+            </g>
+         </svg>
+      );
+      if (graph.data) {
+         graph.data.style = { ...graph.data.style, ...this.getGridStyle(model, context), ...this.renderStyle(context) };
+      }
+      return graph;
+   }
+
+   protected renderAdditionals(context: RenderingContext): VNode[] {
+      const directedEdgeAdds: any = [
+         <defs>
+            <marker
+               id={this.createDefId(MARKER_INHERITANCE_ID)}
+               viewBox='0 0 10 10'
+               refX='10'
+               refY='5'
+               markerUnits='userSpaceOnUse'
+               markerWidth='20'
+               markerHeight='20'
+               orient='auto-start-reverse'
+            >
+               <path d='M 0 0 L 10 5 L 0 10 L 0 0 z' stroke='var(--sprotty-edge)' fill='var(--sprotty-background)' />
+            </marker>
+            <marker
+               id={this.createDefId(MARKER_INHERITANCE_SELECTED_ID)}
+               viewBox='0 0 10 10'
+               refX='10'
+               refY='5'
+               markerUnits='userSpaceOnUse'
+               markerWidth='20'
+               markerHeight='20'
+               orient='auto-start-reverse'
+            >
+               <path d='M 0 0 L 10 5 L 0 10 L 0 0 z' stroke='var(--sprotty-edge-selected)' fill='var(--sprotty-background)' />
+            </marker>
+         </defs>
+      ];
+
+      return directedEdgeAdds;
+   }
+
+   protected renderStyle(context: RenderingContext): VNodeStyle {
+      return {
+         height: '100%',
+         '--svg-def-marker-inheritance': `url(#${this.createDefId(MARKER_INHERITANCE_ID)})`,
+         '--svg-def-marker-inheritance-selected': `url(#${this.createDefId(MARKER_INHERITANCE_SELECTED_ID)})`
+      };
+   }
+}

--- a/packages/glsp-client/src/browser/views.tsx
+++ b/packages/glsp-client/src/browser/views.tsx
@@ -1,6 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2024 CrossBreeze.
  ********************************************************************************/
+/** @jsx svg */
 /* eslint-disable react/no-unknown-property */
 /* eslint-disable max-len */
 
@@ -9,9 +10,6 @@ import { ReactNode } from '@theia/core/shared/react';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
 import { AttributeCompartment } from './model';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const JSX = { createElement: svg };
 
 @injectable()
 export class DiagramNodeView extends RoundedCornerNodeView {

--- a/packages/glsp-client/style/diagram.css
+++ b/packages/glsp-client/style/diagram.css
@@ -3,8 +3,9 @@
  ********************************************************************************/
 
 :root {
-   --sprotty-background: var(--theia-layout-color3);
-   --sprotty-edge: var(--theia-editor-foreground);
+   --sprotty-background: var(--theia-editor-background);
+   --sprotty-edge: #6d6d6d;
+   --sprotty-edge-selected: var(--theia-focusBorder);
    --sprotty-border: var(--theia-editor-foreground);
 }
 
@@ -21,6 +22,7 @@
    font-size: 15pt;
    height: 100%;
    background-size: 11px;
+   background: var(--sprotty-background);
 }
 
 .sprotty
@@ -42,8 +44,12 @@
 }
 
 .sprotty-edge {
-   stroke: #6d6d6d;
+   stroke: var(--sprotty-edge);
    stroke-width: 2px;
+}
+
+.sprotty-edge.selected {
+   stroke: var(--sprotty-edge-selected);
 }
 
 /* Nodes */
@@ -184,4 +190,13 @@
 .error-extension {
    position: absolute;
    width: 100%;
+}
+
+.diagram-edge.inheritance {
+   marker-end: var(--svg-def-marker-inheritance);
+}
+
+.diagram-edge.inheritance.selected,
+.diagram-edge.inheritance.mouseover {
+   marker-end: var(--svg-def-marker-inheritance-selected);
 }

--- a/packages/glsp-client/style/diagram.css
+++ b/packages/glsp-client/style/diagram.css
@@ -77,7 +77,8 @@
 
 .attribute-compartment.mouseover,
 .sprotty-node.mouseover:not(.selected),
-.sprotty-edge.mouseover:not(.selected) {
+.sprotty-edge.mouseover:not(.selected),
+.source-highlight > .sprotty-node {
    stroke: var(--theia-focusBorder);
    stroke-width: 2px;
    opacity: 1;
@@ -94,7 +95,8 @@
 .attribute-compartment.mouseover,
 .attribute-compartment.selected,
 .sprotty-node.mouseover:not(.selected),
-.sprotty-node.selected {
+.sprotty-node.selected,
+.source-highlight > .sprotty-node {
    fill: #f3faff;
    stroke-width: 2px;
 }

--- a/packages/protocol/src/glsp/types.ts
+++ b/packages/protocol/src/glsp/types.ts
@@ -7,6 +7,7 @@ import { Args, DefaultTypes } from '@eclipse-glsp/protocol';
 // System Diagram
 export const ENTITY_NODE_TYPE = DefaultTypes.NODE + ':entity';
 export const RELATIONSHIP_EDGE_TYPE = DefaultTypes.EDGE + ':relationship';
+export const INHERITANCE_EDGE_TYPE = DefaultTypes.EDGE + ':inheritance';
 export const LABEL_ENTITY = DefaultTypes.LABEL + ':entity';
 
 // Mapping Diagram


### PR DESCRIPTION
- Render entity inheritances as entity edges
- Extend edge creation tool to enable creation of new inheritances
- Add inheritance creation tool to tool box
- Add operation/command handlers on server side for inheritance creation & deletion

Also:
- Update tsconfig of vscode extension to fix ts errors related to inversify property injection
- Fix wrong entity initialization in create operation handler