### PR TITLE
Improving syncing between editors on save

### DIFF
--- a/packages/composite-editor/package.json
+++ b/packages/composite-editor/package.json
@@ -34,7 +34,8 @@
     "@eclipse-glsp/theia-integration": "2.3.0",
     "@theia/core": "1.57.1",
     "@theia/editor": "1.57.1",
-    "@theia/editor-preview": "1.57.1"
+    "@theia/editor-preview": "1.57.1",
+    "@theia/filesystem": "1.57.1"
   },
   "theiaExtensions": [
     {

--- a/packages/composite-editor/src/browser/composite-editor-frontend-module.ts
+++ b/packages/composite-editor/src/browser/composite-editor-frontend-module.ts
@@ -8,6 +8,8 @@ import { EditorPreviewManager } from '@theia/editor-preview/lib/browser/editor-p
 import { CompositeEditor } from './composite-editor';
 import { CompositeEditorOpenHandler, CompositeEditorOptions } from './composite-editor-open-handler';
 import { CrossModelEditorManager } from './cross-model-editor-manager';
+import { CrossModelFileResourceResolver } from './cross-model-file-resource-resolver';
+import { FileResourceResolver } from '@theia/filesystem/lib/browser';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
    bind(CrossModelEditorManager).toSelf().inSingletonScope();
@@ -24,4 +26,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
          return container.resolve(CompositeEditor);
       }
    }));
+
+   bind(CrossModelFileResourceResolver).toSelf().inSingletonScope();
+   rebind(FileResourceResolver).toService(CrossModelFileResourceResolver);
 });

--- a/packages/composite-editor/src/browser/cross-model-file-resource-resolver.ts
+++ b/packages/composite-editor/src/browser/cross-model-file-resource-resolver.ts
@@ -1,0 +1,28 @@
+/********************************************************************************
+ * Copyright (c) 2025 CrossBreeze.
+ ********************************************************************************/
+
+import { URI } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
+import { FileResourceResolver } from '@theia/filesystem/lib/browser';
+
+@injectable()
+export class CrossModelFileResourceResolver extends FileResourceResolver {
+   protected _autoOverwrite = false;
+
+   get autoOverwrite(): boolean {
+      return this._autoOverwrite;
+   }
+
+   set autoOverwrite(value: boolean) {
+      this._autoOverwrite = value;
+   }
+
+   protected override async shouldOverwrite(uri: URI): Promise<boolean> {
+      if (this.autoOverwrite) {
+         return true;
+      }
+      // default: ask user via dialog whether they want to overwrite the file content
+      return super.shouldOverwrite(uri);
+   }
+}


### PR DESCRIPTION
- Allow flag to skip overwrite dialog
- Only save a single editor to save the file only once

Fix https://github.com/CrossBreezeNL/crossmodel/issues/82