### PR TITLE
Ensure we re-use existing target attribute for mappings

### DIFF
--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
@@ -44,7 +44,7 @@ export class MappingEdgeCreationOperationHandler extends JsonCreateEdgeOperation
             return;
          }
          const sourceAttributeReference = combineIds(getOwner(sourceElement).id, sourceElement.id);
-         const existingMapping = container.mappings.find(mapping => mapping.attribute.value.ref === targetElement);
+         const existingMapping = container.mappings.find(mapping => mapping.attribute.value.ref?.id === targetElement.id);
          if (existingMapping) {
             existingMapping.sources.push(createAttributeMappingSource(existingMapping, sourceAttributeReference));
          } else {


### PR DESCRIPTION
- Make search safer by using id instead of object equality

Fixes https://github.com/CrossBreezeNL/crossmodel/issues/99