### PR TITLE
Add label to form editor title

### DIFF
--- a/packages/form-client/src/browser/form-editor-widget.tsx
+++ b/packages/form-client/src/browser/form-editor-widget.tsx
@@ -5,7 +5,7 @@
 import { CrossModelWidget, CrossModelWidgetOptions } from '@crossbreeze/core/lib/browser';
 import { NavigatableWidget, NavigatableWidgetOptions } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 
 export interface FormEditorWidgetOptions extends CrossModelWidgetOptions, NavigatableWidgetOptions {
    uri: string;
@@ -17,6 +17,12 @@ export class FormEditorWidget extends CrossModelWidget implements NavigatableWid
 
    protected override handleOpenRequest = undefined; // we do not need to support opening in editor, we are the editor
    protected override handleSaveRequest = undefined; // we do not need to support saving through the widget itself, we are a Theia editor
+
+   @postConstruct()
+   override init(): void {
+      super.init();
+      this.title.label = this.labelProvider.getName(new URI(this.options.uri));
+   }
 
    getResourceUri(): URI {
       return new URI(this.options.uri);


### PR DESCRIPTION
At the moment, there is no label on the tabs for form editors if they are not part of a composite editor; this adds one.

## To Test

1. Open an item that can be opened in a form using the 'Open with...' action.
2. The form should appear, and its tab should have a label.