### PR TITLE
Renamed Entity to LogicalEntity and added identifiers property

### DIFF
--- a/e2e-tests/src/page-objects/cm-properties-view.ts
+++ b/e2e-tests/src/page-objects/cm-properties-view.ts
@@ -4,7 +4,7 @@
 import { ElementHandle } from '@playwright/test';
 import { TheiaApp, TheiaEditor, isElementVisible } from '@theia/playwright';
 import { CMForm } from './form/cm-form';
-import { EntityForm } from './form/entiy-form';
+import { LogicalEntityForm } from './form/entiy-form';
 import { RelationshipForm } from './form/relationship-form';
 
 const CMPropertiesViewData = {
@@ -36,9 +36,9 @@ export abstract class CMPropertiesView<F extends CMForm> extends TheiaEditor {
    }
 }
 
-export class EntityPropertiesView extends CMPropertiesView<EntityForm> {
-   async form(): Promise<EntityForm> {
-      const entityForm = new EntityForm(this, this.modelRootSelector);
+export class EntityPropertiesView extends CMPropertiesView<LogicalEntityForm> {
+   async form(): Promise<LogicalEntityForm> {
+      const entityForm = new LogicalEntityForm(this, this.modelRootSelector);
       await entityForm.waitForVisible();
       return entityForm;
    }

--- a/e2e-tests/src/page-objects/form/cm-form.ts
+++ b/e2e-tests/src/page-objects/form/cm-form.ts
@@ -8,7 +8,7 @@ import { TheiaPageObject, TheiaView } from '@theia/playwright';
 import { TheiaViewObject } from '../theia-view-object';
 
 export const FormIcons = {
-   Entity: 'codicon-git-commit',
+   LogicalEntity: 'codicon-git-commit',
    Relationship: 'codicon-git-compare',
    SystemDiagram: 'codicon-type-hierarchy-sub',
    Mapping: 'codicon-group-by-ref-type'

--- a/e2e-tests/src/page-objects/form/entiy-form.ts
+++ b/e2e-tests/src/page-objects/form/entiy-form.ts
@@ -8,21 +8,21 @@ import { TheiaPageObject } from '@theia/playwright';
 import { TheiaView } from '@theia/playwright/lib/theia-view';
 import { CMForm, FormIcons, FormSection } from './cm-form';
 
-export class EntityForm extends CMForm {
-   protected override iconClass = FormIcons.Entity;
+export class LogicalEntityForm extends CMForm {
+   protected override iconClass = FormIcons.LogicalEntity;
 
-   readonly generalSection: EntityGeneralSection;
-   readonly attributesSection: EntityAttributesSection;
+   readonly generalSection: LogicalEntityGeneralSection;
+   readonly attributesSection: LogicalEntityAttributesSection;
 
    constructor(view: TheiaView, relativeSelector: string) {
-      super(view, relativeSelector, 'Entity');
-      this.generalSection = new EntityGeneralSection(this);
-      this.attributesSection = new EntityAttributesSection(this);
+      super(view, relativeSelector, 'LogicalEntity');
+      this.generalSection = new LogicalEntityGeneralSection(this);
+      this.attributesSection = new LogicalEntityAttributesSection(this);
    }
 }
 
-export class EntityGeneralSection extends FormSection {
-   constructor(form: EntityForm) {
+export class LogicalEntityGeneralSection extends FormSection {
+   constructor(form: LogicalEntityForm) {
       super(form, 'General');
    }
 
@@ -45,9 +45,9 @@ export class EntityGeneralSection extends FormSection {
    }
 }
 
-export class EntityAttributesSection extends FormSection {
+export class LogicalEntityAttributesSection extends FormSection {
    readonly addButtonLocator: Locator;
-   constructor(form: EntityForm) {
+   constructor(form: LogicalEntityForm) {
       super(form, 'Attributes');
       this.addButtonLocator = this.locator.locator('button:has-text("Add Attribute")');
    }
@@ -120,7 +120,7 @@ export type LogicalAttributeDatatype = keyof typeof LogicalAttributeDatatype;
 export class LogicalAttribute extends TheiaPageObject {
    constructor(
       readonly locator: Locator,
-      section: EntityAttributesSection
+      section: LogicalEntityAttributesSection
    ) {
       super(section.app);
    }

--- a/e2e-tests/src/page-objects/form/integrated-form-editor.ts
+++ b/e2e-tests/src/page-objects/form/integrated-form-editor.ts
@@ -7,7 +7,7 @@ import { join } from 'path';
 import { CMCompositeEditor, hasViewError } from '../cm-composite-editor';
 import { IntegratedEditor } from '../cm-integrated-editor';
 import { CMForm } from './cm-form';
-import { EntityForm } from './entiy-form';
+import { LogicalEntityForm } from './entiy-form';
 import { RelationshipForm } from './relationship-form';
 export class IntegratedFormEditor extends IntegratedEditor {
    constructor(filePath: string, parent: CMCompositeEditor, tabSelector: string) {
@@ -26,11 +26,11 @@ export class IntegratedFormEditor extends IntegratedEditor {
       return hasViewError(this.page, this.viewSelector, errorMessage);
    }
 
-   async formFor(entity: 'entity'): Promise<EntityForm>;
+   async formFor(logicalEntity: 'entity'): Promise<LogicalEntityForm>;
    async formFor(relationship: 'relationship'): Promise<RelationshipForm>;
    async formFor(string: 'entity' | 'relationship'): Promise<CMForm> {
       if (string === 'entity') {
-         const form = new EntityForm(this, '');
+         const form = new LogicalEntityForm(this, '');
          await form.waitForVisible();
          return form;
       } else {

--- a/e2e-tests/src/page-objects/system-diagram/diagram-elements.ts
+++ b/e2e-tests/src/page-objects/system-diagram/diagram-elements.ts
@@ -31,9 +31,9 @@ const LabelHeaderMixin = Mix(PLabel).flow(useClickableFlow).flow(useRenameableFl
 @ModelElementMetadata({
    type: 'label:entity'
 })
-export class LabelEntity extends LabelHeaderMixin {}
+export class LabelLogicalEntity extends LabelHeaderMixin {}
 
-const EntityMixin = Mix(PNode)
+const LogicalEntityMixin = Mix(PNode)
    .flow(useClickableFlow)
    .flow(useHoverableFlow)
    .flow(useDeletableFlow)
@@ -48,28 +48,28 @@ const EntityMixin = Mix(PNode)
 @NodeMetadata({
    type: 'node:entity'
 })
-export class Entity extends EntityMixin {
-   override readonly children = new EntityChildren(this);
+export class LogicalEntity extends LogicalEntityMixin {
+   override readonly children = new LogicalEntityChildren(this);
 
    get label(): Promise<string> {
       return this.children.label().then(label => label.textContent());
    }
 }
 
-export class EntityChildren extends ChildrenAccessor {
-   async label(): Promise<LabelEntity> {
-      return this.ofType(LabelEntity, { selector: SVGMetadataUtils.typeAttrOf(LabelEntity) });
+export class LogicalEntityChildren extends ChildrenAccessor {
+   async label(): Promise<LabelLogicalEntity> {
+      return this.ofType(LabelLogicalEntity, { selector: SVGMetadataUtils.typeAttrOf(LabelLogicalEntity) });
    }
 
-   async attributes(): Promise<Attribute[]> {
-      return this.allOfType(Attribute);
+   async attributes(): Promise<LogicalAttribute[]> {
+      return this.allOfType(LogicalAttribute);
    }
 }
 
 @ModelElementMetadata({
    type: 'comp:attribute'
 })
-export class Attribute extends PModelElement {
+export class LogicalAttribute extends PModelElement {
    override async snapshot(): Promise<PModelElementSnapshot & { name: string; datatype: string }> {
       return {
          ...(await super.snapshot()),

--- a/e2e-tests/src/page-objects/system-diagram/integrated-system-diagram-editor.ts
+++ b/e2e-tests/src/page-objects/system-diagram/integrated-system-diagram-editor.ts
@@ -9,7 +9,7 @@ import { CMCompositeEditor, hasViewError } from '../cm-composite-editor';
 import { IntegratedEditor } from '../cm-integrated-editor';
 import { EntityPropertiesView } from '../cm-properties-view';
 import { CMTheiaIntegration } from '../cm-theia-integration';
-import { Entity } from './diagram-elements';
+import { LogicalEntity } from './diagram-elements';
 import { SystemDiagram, WaitForModelUpdateOptions } from './system-diagram';
 import { SystemTools } from './system-tool-box';
 
@@ -49,22 +49,22 @@ export class IntegratedSystemDiagramEditor extends IntegratedEditor {
       return paletteItem.click();
    }
 
-   async getEntity(entityLabel: string): Promise<Entity> {
-      return this.diagram.graph.getNodeByLabel(entityLabel, Entity);
+   async getLogicalEntity(logicalEntityLabel: string): Promise<LogicalEntity> {
+      return this.diagram.graph.getNodeByLabel(logicalEntityLabel, LogicalEntity);
    }
 
-   async getEntities(entityLabel: string): Promise<Entity[]> {
-      return this.diagram.graph.getNodesByLabel(entityLabel, Entity);
+   async getLogicalEntities(logicalEntityLabel: string): Promise<LogicalEntity[]> {
+      return this.diagram.graph.getNodesByLabel(logicalEntityLabel, LogicalEntity);
    }
 
-   async findEntity(entityLabel: string): Promise<Entity | undefined> {
-      const entities = await this.diagram.graph.getNodesByLabel(entityLabel, Entity);
-      return entities.length > 0 ? entities[0] : undefined;
+   async findLogicalEntity(logicalEntityLabel: string): Promise<LogicalEntity | undefined> {
+      const logicalEntities = await this.diagram.graph.getNodesByLabel(logicalEntityLabel, LogicalEntity);
+      return logicalEntities.length > 0 ? logicalEntities[0] : undefined;
    }
 
-   async selectEntityAndOpenProperties(entityLabel: string): Promise<EntityPropertiesView> {
-      const entity = await this.diagram.graph.getNodeByLabel(entityLabel, Entity);
-      await entity.select();
+   async selectLogicalEntityAndOpenProperties(logicalEntityLabel: string): Promise<EntityPropertiesView> {
+      const logicalEntity = await this.diagram.graph.getNodeByLabel(logicalEntityLabel, LogicalEntity);
+      await logicalEntity.select();
       const view = new EntityPropertiesView(this.app);
       if (!(await view.isTabVisible())) {
          await this.page.keyboard.press('Alt+Shift+P');
@@ -77,7 +77,7 @@ export class IntegratedSystemDiagramEditor extends IntegratedEditor {
     * Invoke the 'Show Entity` tool at the given position.
     * i.e. select the tool and click at the given position.
     */
-   async invokeShowEntityToolAtPosition(position: InteractablePosition): Promise<void> {
+   async invokeShowLogicalEntityToolAtPosition(position: InteractablePosition): Promise<void> {
       await this.enableTool('Show Entity');
       // Wait for the insert-indicator to appear
       await this.page.waitForSelector('.insert-indicator', { state: 'attached' });

--- a/e2e-tests/src/page-objects/system-diagram/system-tool-box.ts
+++ b/e2e-tests/src/page-objects/system-diagram/system-tool-box.ts
@@ -20,7 +20,7 @@ export class SystemToolBox extends GLSPToolPalette {
 }
 
 export interface SystemTools {
-   default: 'Select & Move' | 'Hide' | 'Show Entity' | 'Create Entity' | 'Create 1:1 Relationship';
+   default: 'Select & Move' | 'Hide' | 'Show Entity' | 'Create Entity' | 'Create Relationship';
 }
 
 export class SystemToolBoxContent extends GLSPToolPaletteContent {

--- a/e2e-tests/src/tests/diagram/system/add-edit-delete-attributes.spec.ts
+++ b/e2e-tests/src/tests/diagram/system/add-edit-delete-attributes.spec.ts
@@ -4,7 +4,7 @@
 import { expect } from '@eclipse-glsp/glsp-playwright';
 import { test } from '@playwright/test';
 import { CMApp } from '../../../page-objects/cm-app';
-import { Attribute } from '../../../page-objects/system-diagram/diagram-elements';
+import { LogicalAttribute } from '../../../page-objects/system-diagram/diagram-elements';
 
 test.describe.serial('Add/Edit/Delete attributes to/from an entity in a diagram', () => {
    let app: CMApp;
@@ -23,8 +23,8 @@ test.describe.serial('Add/Edit/Delete attributes to/from an entity in a diagram'
    test('Add attribute via properties view', async () => {
       // Open the system diagram, select the existing empty entity and add an attribute via the property widget.
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
-      await diagramEditor.waitForCreationOfType(Attribute, async () => {
-         const propertyView = await diagramEditor.selectEntityAndOpenProperties(EMPTY_ENTITY_ID);
+      await diagramEditor.waitForCreationOfType(LogicalAttribute, async () => {
+         const propertyView = await diagramEditor.selectLogicalEntityAndOpenProperties(EMPTY_ENTITY_ID);
          const form = await propertyView.form();
          const attribute = await form.attributesSection.addAttribute();
          await form.waitForDirty();
@@ -36,7 +36,7 @@ test.describe.serial('Add/Edit/Delete attributes to/from an entity in a diagram'
       });
 
       // Verify that the attribute is added to the diagram
-      const entity = await diagramEditor.getEntity(EMPTY_ENTITY_ID);
+      const entity = await diagramEditor.getLogicalEntity(EMPTY_ENTITY_ID);
       const attributeNodes = await entity.children.attributes();
       expect(attributeNodes).toHaveLength(1);
       const attributeNode = attributeNodes[0];
@@ -60,7 +60,7 @@ test.describe.serial('Add/Edit/Delete attributes to/from an entity in a diagram'
    test('Edit attribute  via properties view', async () => {
       // Open the system diagram, select the entity and edit the new attribute via the property widget.
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
-      const propertyView = await diagramEditor.selectEntityAndOpenProperties(EMPTY_ENTITY_ID);
+      const propertyView = await diagramEditor.selectLogicalEntityAndOpenProperties(EMPTY_ENTITY_ID);
       const form = await propertyView.form();
       const attribute = await form.attributesSection.getAttribute('New Attribute');
 
@@ -92,7 +92,7 @@ test.describe.serial('Add/Edit/Delete attributes to/from an entity in a diagram'
    test('Delete the attribute via properties view', async () => {
       // Open the system diagram, select the entity and delete the attribute via the property widget.
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
-      const propertyView = await diagramEditor.selectEntityAndOpenProperties(EMPTY_ENTITY_ID);
+      const propertyView = await diagramEditor.selectLogicalEntityAndOpenProperties(EMPTY_ENTITY_ID);
       const form = await propertyView.form();
       await diagramEditor.waitForModelUpdate(async () => {
          await form.attributesSection.deleteAttribute(RENAMED_ATTRIBUTE_LABEL);
@@ -114,7 +114,7 @@ test.describe.serial('Add/Edit/Delete attributes to/from an entity in a diagram'
 
       // Verify that the attribute node is deleted from the diagram
       await diagramEditor.activate();
-      const entity = await diagramEditor.getEntity(EMPTY_ENTITY_ID);
+      const entity = await diagramEditor.getLogicalEntity(EMPTY_ENTITY_ID);
       const attributeNodes = await entity.children.attributes();
       expect(attributeNodes).toHaveLength(0);
       await diagramEditor.saveAndClose();

--- a/e2e-tests/src/tests/diagram/system/add-edit-delete-entity.spec.ts
+++ b/e2e-tests/src/tests/diagram/system/add-edit-delete-entity.spec.ts
@@ -4,7 +4,7 @@
 import { expect } from '@eclipse-glsp/glsp-playwright';
 import { test } from '@playwright/test';
 import { CMApp } from '../../../page-objects/cm-app';
-import { Entity } from '../../../page-objects/system-diagram/diagram-elements';
+import { LogicalEntity } from '../../../page-objects/system-diagram/diagram-elements';
 
 test.describe.serial('Add/Edit/Delete entity in a diagram ', () => {
    let app: CMApp;
@@ -24,15 +24,15 @@ test.describe.serial('Add/Edit/Delete entity in a diagram ', () => {
    test('Create new entity via toolbox', async () => {
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
       // Create new entity
-      await diagramEditor.waitForCreationOfType(Entity, async () => {
-         const existingEntity = await diagramEditor.getEntity('EmptyEntity');
+      await diagramEditor.waitForCreationOfType(LogicalEntity, async () => {
+         const existingEntity = await diagramEditor.getLogicalEntity('EmptyEntity');
          await diagramEditor.enableTool('Create Entity');
          const taskBounds = await existingEntity.bounds();
          await taskBounds.position('top_center').moveRelative(0, -100).click();
       });
 
       // Verify that the entity node was created as expected in the diagram
-      const newEntity = await diagramEditor.getEntity(NEW_ENTITY_LABEL);
+      const newEntity = await diagramEditor.getLogicalEntity(NEW_ENTITY_LABEL);
       expect(newEntity).toBeDefined();
 
       // Switch to diagram code editor and check the file contains the new entity node
@@ -62,7 +62,7 @@ test.describe.serial('Add/Edit/Delete entity in a diagram ', () => {
       // Open the system diagram with the new entity
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
       // Open the property widget of the new entity and update it's name and description
-      const properties = await diagramEditor.selectEntityAndOpenProperties(NEW_ENTITY_LABEL);
+      const properties = await diagramEditor.selectLogicalEntityAndOpenProperties(NEW_ENTITY_LABEL);
       const form = await properties.form();
       await form.generalSection.setName(RENAMED_ENTITY_LABEL);
       await form.generalSection.setDescription(RENAMED_ENTITY_DESCRIPTION);
@@ -87,7 +87,7 @@ test.describe.serial('Add/Edit/Delete entity in a diagram ', () => {
       // Open the system diagram with the renamed entity node
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
       await diagramEditor.activate();
-      const renamedEntity = await diagramEditor.getEntity(RENAMED_ENTITY_LABEL);
+      const renamedEntity = await diagramEditor.getLogicalEntity(RENAMED_ENTITY_LABEL);
       // Hide the entity node
       await diagramEditor.waitForModelUpdate(async () => {
          await diagramEditor.enableTool('Hide');
@@ -96,7 +96,7 @@ test.describe.serial('Add/Edit/Delete entity in a diagram ', () => {
 
       // Check if entity is actually just hidden, i.e. can be shown again
       const position = (await diagramEditor.diagram.graph.bounds()).position('middle_center');
-      await diagramEditor.invokeShowEntityToolAtPosition(position);
+      await diagramEditor.invokeShowLogicalEntityToolAtPosition(position);
       const entitySuggestions = await diagramEditor.diagram.globalCommandPalette.suggestions();
       // The suggestions are Ids and the Id property of the new entity hasn't changed (yet).
       expect(entitySuggestions).toContain(NEW_ENTITY_LABEL);
@@ -112,7 +112,7 @@ test.describe.serial('Add/Edit/Delete entity in a diagram ', () => {
       // Open the system diagram and check the entity is not listed in the suggestions anymore.
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
       const position = (await diagramEditor.diagram.graph.bounds()).position('middle_center');
-      await diagramEditor.invokeShowEntityToolAtPosition(position);
+      await diagramEditor.invokeShowLogicalEntityToolAtPosition(position);
       const entitySuggestions = await diagramEditor.diagram.globalCommandPalette.suggestions();
       expect(entitySuggestions).not.toContain(NEW_ENTITY_LABEL);
 

--- a/e2e-tests/src/tests/diagram/system/add-edit-delete-relationship.spec.ts
+++ b/e2e-tests/src/tests/diagram/system/add-edit-delete-relationship.spec.ts
@@ -23,19 +23,19 @@ test.describe.serial('Add/Edit/Delete relationship in a diagram ', () => {
    });
 
    async function getNewRelationship(diagramEditor: IntegratedSystemDiagramEditor): Promise<Relationship> {
-      const sourceEntity = await diagramEditor.getEntity(CUSTOMER_ENTITY_ID);
-      const targetEntity = await diagramEditor.getEntity(ORDER_ENTITY_ID);
+      const sourceEntity = await diagramEditor.getLogicalEntity(CUSTOMER_ENTITY_ID);
+      const targetEntity = await diagramEditor.getLogicalEntity(ORDER_ENTITY_ID);
       return diagramEditor.diagram.graph.getEdgeBetween(Relationship, { sourceNode: sourceEntity, targetNode: targetEntity });
    }
 
    test('Create new relationship via toolbox', async () => {
       // Open the system diagram and create a relationship between the customer and order entity using the '1:1 Relationship tool'.
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
-      const sourceEntity = await diagramEditor.getEntity(CUSTOMER_ENTITY_ID);
-      const targetEntity = await diagramEditor.getEntity(ORDER_ENTITY_ID);
+      const sourceEntity = await diagramEditor.getLogicalEntity(CUSTOMER_ENTITY_ID);
+      const targetEntity = await diagramEditor.getLogicalEntity(ORDER_ENTITY_ID);
 
       await diagramEditor.waitForCreationOfType(Relationship, async () => {
-         await diagramEditor.enableTool('Create 1:1 Relationship');
+         await diagramEditor.enableTool('Create Relationship');
          const targetPosition = (await targetEntity.bounds()).position('middle_center');
          await sourceEntity.dragToAbsolutePosition(targetPosition.data);
       });

--- a/e2e-tests/src/tests/diagram/system/add-existing-entity.spec.ts
+++ b/e2e-tests/src/tests/diagram/system/add-existing-entity.spec.ts
@@ -4,7 +4,7 @@
 import { expect } from '@eclipse-glsp/glsp-playwright';
 import { test } from '@playwright/test';
 import { CMApp } from '../../../page-objects/cm-app';
-import { Entity } from '../../../page-objects/system-diagram/diagram-elements';
+import { LogicalEntity } from '../../../page-objects/system-diagram/diagram-elements';
 
 test.describe.serial('Add existing entity to a diagram', () => {
    let app: CMApp;
@@ -22,14 +22,14 @@ test.describe.serial('Add existing entity to a diagram', () => {
       // Open the system diagram and add the existing entity via the 'Show Entity' tool.
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
       const diagram = diagramEditor.diagram;
-      await diagram.graph.waitForCreationOfType(Entity, async () => {
+      await diagram.graph.waitForCreationOfType(LogicalEntity, async () => {
          const position = (await diagram.graph.bounds()).position('middle_center');
-         await diagramEditor.invokeShowEntityToolAtPosition(position);
+         await diagramEditor.invokeShowLogicalEntityToolAtPosition(position);
          await diagram.globalCommandPalette.search(CUSTOMER_ENTITY_ID, { confirm: true });
       });
 
       // Verify that the entity node was created as expected
-      const customer = await diagramEditor.getEntity(CUSTOMER_ENTITY_ID);
+      const customer = await diagramEditor.getLogicalEntity(CUSTOMER_ENTITY_ID);
       expect(customer).toBeDefined();
 
       // Open the diagram code editor and check the Customer entity node was added.
@@ -47,13 +47,13 @@ test.describe.serial('Add existing entity to a diagram', () => {
       // Open the system diagram and add the existing customer entity via keyboard shortcut.
       const diagramEditor = await app.openCompositeEditor(SYSTEM_DIAGRAM_PATH, 'System Diagram');
       const diagram = diagramEditor.diagram;
-      await diagram.graph.waitForCreationOfType(Entity, async () => {
+      await diagram.graph.waitForCreationOfType(LogicalEntity, async () => {
          await diagram.globalCommandPalette.open();
          await diagram.globalCommandPalette.search(CUSTOMER_ENTITY_ID, { confirm: true });
       });
 
       // Verify that the entity node was created as expected (at this point we have 2 customer nodes).
-      const customers = await diagramEditor.getEntities(CUSTOMER_ENTITY_ID);
+      const customers = await diagramEditor.getLogicalEntities(CUSTOMER_ENTITY_ID);
       expect(customers).toHaveLength(2);
 
       // Open the diagram code editor and check the second Customer entity node is added.

--- a/e2e-tests/src/tests/model/add-delete-model.spec.ts
+++ b/e2e-tests/src/tests/model/add-delete-model.spec.ts
@@ -85,7 +85,7 @@ test.describe.serial('Add/Edit/Delete model from explorer', () => {
       const menuItem = await contextMenu.menuItemByNamePath('New Element', 'Data Model...');
       expect(menuItem).toBeDefined();
       await menuItem?.click();
-      await confirmCreationDialog(app, 'NewModel2', 'physical', '0.0.2');
+      await confirmCreationDialog(app, 'NewModel2', 'relational', '0.0.2');
       await explorer.activate();
 
       // Verify that the model was created as expected

--- a/examples/language-examples/conceptual/entities/Address.entity.cm
+++ b/examples/language-examples/conceptual/entities/Address.entity.cm
@@ -3,12 +3,15 @@ entity:
     name: "Address"
     description: "The address of a customer."
     attributes:
-      - id: CustomerID
-        name: "Customer ID"
+      - id: Customer_Id
+        name: "Customer Id"
       - id: Street
         name: "Street"
       - id: CountryCode
         name: "Country Code"
-    identifier:
-      - attributes:
-        - CustomerID
+    identifiers:
+      - id: Address_Surrogate_Identifier
+        name: "Address Surrogate Identifier"
+        primary: true
+        attributes:
+        - Customer_Id

--- a/examples/language-examples/conceptual/entities/Customer.entity.cm
+++ b/examples/language-examples/conceptual/entities/Customer.entity.cm
@@ -2,8 +2,8 @@ entity:
     id: Customer
     name: "Customer"
     attributes:
-      - id: Id
-        name: "Id"
+      - id: Customer_Id
+        name: "Customer Id"
       - id: First_Name
         name: "First Name"
       - id: Last_Name
@@ -16,6 +16,9 @@ entity:
         name: "Phone"
       - id: Birth_Date
         name: "Birth Date"
-    identifier:
-      - attributes:
-        - Id
+    identifiers:
+      - id: Customer_Surrogate_Identifier
+        name: "Customer Surrogate Identifier"
+        primary: true
+        attributes:
+        - Customer_Id

--- a/examples/language-examples/conceptual/entities/Order.entity.cm
+++ b/examples/language-examples/conceptual/entities/Order.entity.cm
@@ -3,16 +3,18 @@ entity:
     name: "Order"
     description: "Order placed by a customer in the Customer table."
     attributes:
-      - id: Id
-        name: "Id"
+      - id: Order_Id
+        name: "Order Id"
       - id: OrderDate
         name: "OrderDate"
       - id: OrderNumber
         name: "OrderNumber"
-      - id: CustomerId
-        name: "CustomerId"
+      - id: Customer_Id
+        name: "Customer Id"
       - id: TotalAmount
         name: "TotalAmount"
-    identifier:
-      - attributes:
-        - Id
+    identifiers:
+      - id: Order_Surrogate_Identifier
+        name: "Order Surrogate Identifier"
+        attributes:
+          - Order_Id

--- a/examples/language-examples/logical/entities/Address.entity.cm
+++ b/examples/language-examples/logical/entities/Address.entity.cm
@@ -3,8 +3,8 @@ entity:
     name: "Address"
     description: "The address of a customer."
     attributes:
-      - id: CustomerID
-        name: "Customer ID"
+      - id: Customer_Id
+        name: "Customer Id"
         datatype: "Integer"
       - id: Street
         name: "Street"
@@ -18,10 +18,13 @@ entity:
           - name: Author
             value: "CrossBreeze"
           - name: ExampleEntityAttribute
+    identifiers:
+      - id: Address_Surrogate_Identifier
+        name: "Address Surrogate Identifier"
+        primary: true
+        attributes:
+        - Customer_Id
     customProperties:
       - name: Author
         value: "CrossBreeze"
       - name: ExampleEntity
-    identifier:
-      - attributes:
-        - CustomerID

--- a/examples/language-examples/logical/entities/Customer.entity.cm
+++ b/examples/language-examples/logical/entities/Customer.entity.cm
@@ -2,11 +2,11 @@ entity:
     id: Customer
     name: "Customer"
     attributes:
-      - id: Id
-        name: "Id"
+      - id: Customer_Id
+        name: "Customer Id"
         datatype: "Integer"
-        relatedConceptualAttributes:
-          - id: ExampleCRM_CDM.Customer.Id
+        #relatedConceptualAttributes:
+        #  - id: ExampleCRM_CDM.Customer.Id
       - id: First_Name
         name: "First Name"
         datatype: "Text"
@@ -30,6 +30,19 @@ entity:
       - id: Birth_Date
         name: "Birth Date"
         datatype: "Date"
-    identifier:
-      - attributes:
-        - Id
+    identifiers:
+      - id: Customer_Surrogate_Identifier
+        name: "Customer Surrogate Identifier"
+        primary: true
+        attributes:
+        - Customer_Id
+      - id: Customer_Natural_Identifier
+        name: "Customer Natural Identifier"
+        attributes:
+        - First_Name
+        - Last_Name
+        - Birth_Date
+        customProperties:
+          - name: Author
+            value: "CrossBreeze"
+          - name: ExampleCustomPropertyOnIdentifier

--- a/examples/language-examples/logical/entities/Order.entity.cm
+++ b/examples/language-examples/logical/entities/Order.entity.cm
@@ -3,8 +3,8 @@ entity:
     name: "Order"
     description: "Order placed by a customer in the Customer table."
     attributes:
-      - id: Id
-        name: "Id"
+      - id: Order_Id
+        name: "Order Id"
         datatype: "Integer"
       - id: OrderDate
         name: "OrderDate"
@@ -14,14 +14,16 @@ entity:
         name: "OrderNumber"
         datatype: "Text"
         length: 50
-      - id: CustomerId
-        name: "CustomerId"
+      - id: Customer_Id
+        name: "Customer Id"
         datatype: "Integer"
       - id: TotalAmount
         name: "TotalAmount"
         datatype: "Decimal"
         precision: 38
         scale: 6
-    identifier:
-      - attributes:
-        - Id
+    identifiers:
+      - id: Order_Surrogate_Identifier
+        name: "Order Surrogate Identifier"
+        attributes:
+          - Order_Id

--- a/examples/language-examples/logical/relationships/Address_Customer.relationship.cm
+++ b/examples/language-examples/logical/relationships/Address_Customer.relationship.cm
@@ -6,8 +6,8 @@ relationship:
     child: Address
     childCardinality: multiple
     attributes:
-      - parent: Customer.Id
-        child: Address.CustomerID
+      - parent: Customer.Customer_Id
+        child: Address.Customer_Id
         customProperties:
           - name: Author
             value: "CrossBreeze"

--- a/examples/language-examples/logical/relationships/Order_Customer.relationship.cm
+++ b/examples/language-examples/logical/relationships/Order_Customer.relationship.cm
@@ -6,5 +6,5 @@ relationship:
     child: Order
     childCardinality: multiple
     attributes:
-        - parent: Customer.Id
-          child: Order.CustomerId
+        - parent: Customer.Customer_Id
+          child: Order.Customer_Id

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/command-palette/add-entity-action-provider.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/command-palette/add-entity-action-provider.ts
@@ -4,7 +4,7 @@
 import { AddEntityOperation, codiconCSSString } from '@crossbreeze/protocol';
 import { ContextActionsProvider, EditorContext, LabeledAction, ModelState, Point } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
-import { EntityNode } from '../../../language-server/generated/ast.js';
+import { LogicalEntityNode } from '../../../language-server/generated/ast.js';
 import { SystemModelState } from '../model/system-model-state.js';
 
 /**
@@ -20,7 +20,7 @@ export class SystemDiagramAddEntityActionProvider implements ContextActionsProvi
    async getActions(editorContext: EditorContext): Promise<LabeledAction[]> {
       const completionItems = this.state.services.language.references.ScopeProvider.complete({
          container: { globalId: this.state.systemDiagram.id! },
-         syntheticElements: [{ property: 'nodes', type: EntityNode }],
+         syntheticElements: [{ property: 'nodes', type: LogicalEntityNode }],
          property: 'entity'
       });
       return completionItems.map<LabeledAction>(item => ({

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/edge-checker/edge-checker.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/edge-checker/edge-checker.ts
@@ -4,7 +4,7 @@
 import { INHERITANCE_EDGE_TYPE } from '@crossbreeze/protocol';
 import { EdgeCreationChecker, GModelElement, ModelState, getOrThrow } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
-import { Entity, EntityNode, isInheritanceEdge } from '../../../language-server/generated/ast.js';
+import { LogicalEntity, LogicalEntityNode, isInheritanceEdge } from '../../../language-server/generated/ast.js';
 import { SystemModelState } from '../model/system-model-state.js';
 
 @injectable()
@@ -18,8 +18,8 @@ export class SystemEdgeCreationChecker implements EdgeCreationChecker {
       if (edgeType !== INHERITANCE_EDGE_TYPE) {
          return true;
       }
-      const baseEntityNode = getOrThrow(this.modelState.index.findEntityNode(sourceElement.id), 'Base entity node not found');
-      const superEntityNode = getOrThrow(this.modelState.index.findEntityNode(targetElement.id), 'Super entity node not found');
+      const baseEntityNode = getOrThrow(this.modelState.index.findLogicalEntityNode(sourceElement.id), 'Base entity node not found');
+      const superEntityNode = getOrThrow(this.modelState.index.findLogicalEntityNode(targetElement.id), 'Super entity node not found');
       if (!baseEntityNode.entity.ref || !superEntityNode.entity.ref) {
          return false;
       }
@@ -47,7 +47,7 @@ export class SystemEdgeCreationChecker implements EdgeCreationChecker {
       return true;
    }
 
-   protected hasExistingInheritanceEdge(baseEntityNode: EntityNode, superEntityNode: EntityNode): boolean {
+   protected hasExistingInheritanceEdge(baseEntityNode: LogicalEntityNode, superEntityNode: LogicalEntityNode): boolean {
       const existingInheritanceEdge = this.modelState.systemDiagram.edges.find(edge => {
          if (!isInheritanceEdge(edge)) {
             return false;
@@ -60,7 +60,7 @@ export class SystemEdgeCreationChecker implements EdgeCreationChecker {
       return !!existingInheritanceEdge;
    }
 
-   protected hasSuperEntity(baseEntity: Entity, superEntity: Entity): boolean {
+   protected hasSuperEntity(baseEntity: LogicalEntity, superEntity: LogicalEntity): boolean {
       return baseEntity.superEntities.some(entity => entity.ref === superEntity);
    }
 }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/add-entity-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/add-entity-operation-handler.ts
@@ -5,7 +5,7 @@
 import { AddEntityOperation } from '@crossbreeze/protocol';
 import { Command, JsonOperationHandler, ModelState } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
-import { Entity, EntityNode } from '../../../language-server/generated/ast.js';
+import { LogicalEntity, LogicalEntityNode } from '../../../language-server/generated/ast.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { SystemModelState } from '../model/system-model-state.js';
 
@@ -24,7 +24,7 @@ export class SystemDiagramAddEntityOperationHandler extends JsonOperationHandler
    protected async createEntityNode(operation: AddEntityOperation): Promise<void> {
       const scope = this.modelState.services.language.references.ScopeProvider.getCompletionScope({
          container: { globalId: this.modelState.systemDiagram.id! },
-         syntheticElements: [{ property: 'nodes', type: EntityNode }],
+         syntheticElements: [{ property: 'nodes', type: LogicalEntityNode }],
          property: 'entity'
       });
 
@@ -32,13 +32,13 @@ export class SystemDiagramAddEntityOperationHandler extends JsonOperationHandler
       const entityDescription = scope.elementScope.getElement(operation.entityName);
 
       if (entityDescription) {
-         const node: EntityNode = {
-            $type: EntityNode,
+         const node: LogicalEntityNode = {
+            $type: LogicalEntityNode,
             $container: container,
-            id: this.modelState.idProvider.findNextId(EntityNode, entityDescription.name + 'Node', container),
+            id: this.modelState.idProvider.findNextId(LogicalEntityNode, entityDescription.name + 'Node', container),
             entity: {
                $refText: entityDescription.name,
-               ref: entityDescription.node as Entity | undefined
+               ref: entityDescription.node as LogicalEntity | undefined
             },
             x: operation.position.x,
             y: operation.position.y,

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/apply-edit-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/apply-edit-operation-handler.ts
@@ -5,7 +5,7 @@
 import { toId } from '@crossbreeze/protocol';
 import { ApplyLabelEditOperation, Command, getOrThrow, JsonOperationHandler, ModelState } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
-import { CrossModelRoot, Entity, EntityNode } from '../../../language-server/generated/ast.js';
+import { CrossModelRoot, LogicalEntity, LogicalEntityNode } from '../../../language-server/generated/ast.js';
 import { findDocument } from '../../../language-server/util/ast-util.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { SystemModelState } from '../model/system-model-state.js';
@@ -16,7 +16,7 @@ export class SystemDiagramApplyLabelEditOperationHandler extends JsonOperationHa
    @inject(ModelState) override modelState: SystemModelState;
 
    createCommand(operation: ApplyLabelEditOperation): Command {
-      const entityNode = getOrThrow(this.modelState.index.findEntityNode(operation.labelId), 'Entity node not found');
+      const entityNode = getOrThrow(this.modelState.index.findLogicalEntityNode(operation.labelId), 'Entity node not found');
       const entity = getOrThrow(entityNode.entity.ref, 'Entity not found');
       const oldName = entity.name;
       return new CrossModelCommand(
@@ -24,20 +24,20 @@ export class SystemDiagramApplyLabelEditOperationHandler extends JsonOperationHa
          () => this.renameEntity(entityNode, entity, operation.text),
          () =>
             this.renameEntity(
-               getOrThrow(this.modelState.index.findEntityNode(operation.labelId), 'Entity node not found'),
+               getOrThrow(this.modelState.index.findLogicalEntityNode(operation.labelId), 'Entity node not found'),
                getOrThrow(entityNode.entity.ref, 'Entity not found'),
-               oldName ?? this.modelState.idProvider.findNextId(Entity, 'NewEntity')
+               oldName ?? this.modelState.idProvider.findNextId(LogicalEntity, 'NewEntity')
             ),
          () =>
             this.renameEntity(
-               getOrThrow(this.modelState.index.findEntityNode(operation.labelId), 'Entity node not found'),
+               getOrThrow(this.modelState.index.findLogicalEntityNode(operation.labelId), 'Entity node not found'),
                getOrThrow(entityNode.entity.ref, 'Entity not found'),
                operation.text
             )
       );
    }
 
-   protected async renameEntity(entityNode: EntityNode, entity: Entity, name: string): Promise<void> {
+   protected async renameEntity(entityNode: LogicalEntityNode, entity: LogicalEntity, name: string): Promise<void> {
       entity.name = name;
       const document = findDocument<CrossModelRoot>(entity)!;
       const references = Array.from(
@@ -46,7 +46,7 @@ export class SystemDiagramApplyLabelEditOperationHandler extends JsonOperationHa
       if (references.length === 0 || (references.length === 1 && references[0].sourceUri.fsPath === this.modelState.sourceUri)) {
          // if the diagram is the only reference to the entity, we can safely rename it
          // otherwise we need to ensure to implement proper rename behavior
-         entity.id = this.modelState.idProvider.findNextGlobalId(Entity, toId(entity.name));
+         entity.id = this.modelState.idProvider.findNextGlobalId(LogicalEntity, toId(entity.name));
          entityNode.entity = { $refText: entity.id, ref: entity };
       }
       await this.modelState.modelService.save({

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/change-bounds-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/change-bounds-operation-handler.ts
@@ -17,7 +17,7 @@ export class SystemDiagramChangeBoundsOperationHandler extends JsonOperationHand
 
    protected changeBounds(operation: ChangeBoundsOperation): void {
       operation.newBounds.forEach(elementAndBounds => {
-         const node = this.modelState.index.findEntityNode(elementAndBounds.elementId);
+         const node = this.modelState.index.findLogicalEntityNode(elementAndBounds.elementId);
          if (node) {
             // we store the given bounds directly in our diagram node
             node.x = elementAndBounds.newPosition?.x || node.x;

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-entity-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-entity-operation-handler.ts
@@ -14,7 +14,7 @@ import {
 } from '@eclipse-glsp/server';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { URI, Utils as UriUtils } from 'vscode-uri';
-import { CrossModelRoot, Entity, EntityNode } from '../../../language-server/generated/ast.js';
+import { CrossModelRoot, LogicalEntity, LogicalEntityNode } from '../../../language-server/generated/ast.js';
 import { Utils } from '../../../language-server/util/uri-util.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { SystemModelState } from '../model/system-model-state.js';
@@ -38,10 +38,10 @@ export class SystemDiagramCreateEntityOperationHandler extends JsonCreateNodeOpe
       }
       const container = this.modelState.systemDiagram;
       const location = this.getLocation(operation) ?? Point.ORIGIN;
-      const node: EntityNode = {
-         $type: EntityNode,
+      const node: LogicalEntityNode = {
+         $type: LogicalEntityNode,
          $container: container,
-         id: this.modelState.idProvider.findNextId(EntityNode, entity.name + 'Node', container),
+         id: this.modelState.idProvider.findNextId(LogicalEntityNode, entity.name + 'Node', container),
          entity: {
             $refText: this.modelState.idProvider.getNodeId(entity) || entity.id || '',
             ref: entity
@@ -61,12 +61,12 @@ export class SystemDiagramCreateEntityOperationHandler extends JsonCreateNodeOpe
    /**
     * Creates a new entity and stores it on a file on the file system.
     */
-   protected async createAndSaveEntity(operation: CreateNodeOperation): Promise<Entity | undefined> {
+   protected async createAndSaveEntity(operation: CreateNodeOperation): Promise<LogicalEntity | undefined> {
       // create entity, serialize and re-read to ensure everything is up to date and linked properly
       const entityRoot: CrossModelRoot = { $type: 'CrossModelRoot' };
-      const id = this.modelState.idProvider.findNextId(Entity, 'NewEntity');
-      const entity: Entity = {
-         $type: 'Entity',
+      const id = this.modelState.idProvider.findNextId(LogicalEntity, 'NewEntity');
+      const entity: LogicalEntity = {
+         $type: 'LogicalEntity',
          $container: entityRoot,
          id,
          name: id,

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-inheritance-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-inheritance-operation-handler.ts
@@ -14,7 +14,7 @@ import {
    getOrThrow
 } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
-import { CrossModelRoot, Entity, EntityNode, InheritanceEdge } from '../../../language-server/generated/ast.js';
+import { CrossModelRoot, InheritanceEdge, LogicalEntity, LogicalEntityNode } from '../../../language-server/generated/ast.js';
 import { findDocument } from '../../../language-server/util/ast-util.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { SystemModelState } from '../model/system-model-state.js';
@@ -28,8 +28,14 @@ export class SystemDiagramCreateInheritanceOperationHandler extends JsonCreateEd
    @inject(ActionDispatcher) protected actionDispatcher: ActionDispatcher;
 
    createCommand(operation: CreateEdgeOperation): MaybePromise<Command | undefined> {
-      const baseEntityNode = getOrThrow(this.modelState.index.findEntityNode(operation.sourceElementId), 'Base entity node not found');
-      const superEntityNode = getOrThrow(this.modelState.index.findEntityNode(operation.targetElementId), 'Super entity node not found');
+      const baseEntityNode = getOrThrow(
+         this.modelState.index.findLogicalEntityNode(operation.sourceElementId),
+         'Base entity node not found'
+      );
+      const superEntityNode = getOrThrow(
+         this.modelState.index.findLogicalEntityNode(operation.targetElementId),
+         'Super entity node not found'
+      );
       if (!baseEntityNode.entity.ref || !superEntityNode.entity.ref) {
          return undefined;
       }
@@ -56,7 +62,7 @@ export class SystemDiagramCreateInheritanceOperationHandler extends JsonCreateEd
       return new CompoundCommand(new AddInheritanceCommand(this.modelState, operation), diagramCommand);
    }
 
-   protected async createEdge(baseEntityNode: EntityNode, superEntityNode: EntityNode): Promise<void> {
+   protected async createEdge(baseEntityNode: LogicalEntityNode, superEntityNode: LogicalEntityNode): Promise<void> {
       const edge: InheritanceEdge = {
          $type: InheritanceEdge,
          $container: this.modelState.systemDiagram,
@@ -90,8 +96,8 @@ export class AddInheritanceCommand implements Command {
          return;
       }
 
-      const baseEntity = this.modelState.index.findEntityNode(this.operation.sourceElementId)?.entity.ref;
-      const superEntity = this.modelState.index.findEntityNode(this.operation.targetElementId)?.entity.ref;
+      const baseEntity = this.modelState.index.findLogicalEntityNode(this.operation.sourceElementId)?.entity.ref;
+      const superEntity = this.modelState.index.findLogicalEntityNode(this.operation.targetElementId)?.entity.ref;
       if (!baseEntity || !superEntity) {
          return;
       }
@@ -119,8 +125,8 @@ export class AddInheritanceCommand implements Command {
          return;
       }
 
-      const baseEntity = this.modelState.index.findEntityNode(this.operation.sourceElementId)?.entity.ref;
-      const superEntity = this.modelState.index.findEntityNode(this.operation.targetElementId)?.entity.ref;
+      const baseEntity = this.modelState.index.findLogicalEntityNode(this.operation.sourceElementId)?.entity.ref;
+      const superEntity = this.modelState.index.findLogicalEntityNode(this.operation.targetElementId)?.entity.ref;
       if (!baseEntity || !superEntity) {
          return;
       }
@@ -150,6 +156,6 @@ export class AddInheritanceCommand implements Command {
    }
 }
 
-function hasSuperEntity(baseEntity: Entity, superEntity: Entity): boolean {
+function hasSuperEntity(baseEntity: LogicalEntity, superEntity: LogicalEntity): boolean {
    return baseEntity.superEntities.some(entity => entity.ref === superEntity);
 }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-relationship-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-relationship-operation-handler.ts
@@ -13,7 +13,7 @@ import {
 } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import { URI, Utils as UriUtils } from 'vscode-uri';
-import { CrossModelRoot, EntityNode, Relationship, RelationshipEdge } from '../../../language-server/generated/ast.js';
+import { CrossModelRoot, LogicalEntityNode, Relationship, RelationshipEdge } from '../../../language-server/generated/ast.js';
 import { Utils } from '../../../language-server/util/uri-util.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { SystemModelState } from '../model/system-model-state.js';
@@ -31,8 +31,8 @@ export class SystemDiagramCreateRelationshipOperationHandler extends JsonCreateE
    }
 
    protected async createEdge(operation: CreateEdgeOperation): Promise<void> {
-      const sourceNode = this.modelState.index.findEntityNode(operation.sourceElementId);
-      const targetNode = this.modelState.index.findEntityNode(operation.targetElementId);
+      const sourceNode = this.modelState.index.findLogicalEntityNode(operation.sourceElementId);
+      const targetNode = this.modelState.index.findLogicalEntityNode(operation.targetElementId);
 
       if (sourceNode && targetNode) {
          // before we can create a diagram edge, we need to create the corresponding relationship that it is based on
@@ -66,7 +66,10 @@ export class SystemDiagramCreateRelationshipOperationHandler extends JsonCreateE
    /**
     * Creates a new relationship and stores it on a file on the file system.
     */
-   protected async createAndSaveRelationship(sourceNode: EntityNode, targetNode: EntityNode): Promise<Relationship | undefined> {
+   protected async createAndSaveRelationship(
+      sourceNode: LogicalEntityNode,
+      targetNode: LogicalEntityNode
+   ): Promise<Relationship | undefined> {
       const source = sourceNode.entity?.ref?.id || sourceNode.entity?.$refText;
       const target = targetNode.entity?.ref?.id || targetNode.entity?.$refText;
 

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/delete-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/delete-operation-handler.ts
@@ -4,11 +4,11 @@
 import { Command, DeleteElementOperation, JsonOperationHandler, ModelState, remove } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import {
-   EntityNode,
    InheritanceEdge,
-   isEntityNode,
+   isLogicalEntityNode,
    isRelationshipEdge,
    isSystemDiagramEdge,
+   LogicalEntityNode,
    SystemDiagramEdge
 } from '../../../language-server/generated/ast.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
@@ -42,7 +42,7 @@ export class SystemDiagramDeleteOperationHandler extends JsonOperationHandler {
       for (const elementId of operation.elementIds) {
          const element = this.modelState.index.findSemanticElement(elementId, isDiagramElement);
          // simply remove any diagram nodes or edges from the diagram
-         if (isEntityNode(element)) {
+         if (isLogicalEntityNode(element)) {
             deleteInfo.nodes.push(element);
             deleteInfo.edges.push(...this.modelState.systemDiagram.edges.filter(edge => isRelatedEdge(edge, element)));
          } else if (isSystemDiagramEdge(element)) {
@@ -53,7 +53,7 @@ export class SystemDiagramDeleteOperationHandler extends JsonOperationHandler {
    }
 }
 
-function isRelatedEdge(edge: SystemDiagramEdge, node: EntityNode): boolean {
+function isRelatedEdge(edge: SystemDiagramEdge, node: LogicalEntityNode): boolean {
    if (isRelationshipEdge(edge)) {
       return edge.sourceNode?.ref === node || edge.targetNode?.ref === node;
    } else {
@@ -61,11 +61,11 @@ function isRelatedEdge(edge: SystemDiagramEdge, node: EntityNode): boolean {
    }
 }
 
-function isDiagramElement(item: unknown): item is SystemDiagramEdge | EntityNode {
-   return isSystemDiagramEdge(item) || isEntityNode(item);
+function isDiagramElement(item: unknown): item is SystemDiagramEdge | LogicalEntityNode {
+   return isSystemDiagramEdge(item) || isLogicalEntityNode(item);
 }
 
 interface DeleteInfo {
-   nodes: EntityNode[];
+   nodes: LogicalEntityNode[];
    edges: SystemDiagramEdge[];
 }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/drop-entity-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/drop-entity-operation-handler.ts
@@ -6,7 +6,7 @@ import { DropEntityOperation } from '@crossbreeze/protocol';
 import { Command, JsonOperationHandler, ModelState } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import { URI } from 'vscode-uri';
-import { EntityNode } from '../../../language-server/generated/ast.js';
+import { LogicalEntityNode } from '../../../language-server/generated/ast.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { SystemModelState } from '../model/system-model-state.js';
 
@@ -34,10 +34,10 @@ export class SystemDiagramDropEntityOperationHandler extends JsonOperationHandle
          const entity = document?.root?.entity;
          if (entity) {
             // create node for entity
-            const node: EntityNode = {
-               $type: EntityNode,
+            const node: LogicalEntityNode = {
+               $type: LogicalEntityNode,
                $container: container,
-               id: this.modelState.idProvider.findNextId(EntityNode, entity.id + 'Node', this.modelState.systemDiagram),
+               id: this.modelState.idProvider.findNextId(LogicalEntityNode, entity.id + 'Node', this.modelState.systemDiagram),
                entity: {
                   $refText: this.modelState.idProvider.getGlobalId(entity) || entity.id || '',
                   ref: entity

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/nodes.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/nodes.ts
@@ -3,7 +3,7 @@
  ********************************************************************************/
 import { ENTITY_NODE_TYPE, LABEL_ENTITY, REFERENCE_CONTAINER_TYPE, REFERENCE_PROPERTY, REFERENCE_VALUE } from '@crossbreeze/protocol';
 import { ArgsUtil, GNode, GNodeBuilder } from '@eclipse-glsp/server';
-import { EntityNode } from '../../../language-server/generated/ast.js';
+import { LogicalEntityNode } from '../../../language-server/generated/ast.js';
 import { getAttributes } from '../../../language-server/util/ast-util.js';
 import { AttributeCompartment, AttributesCompartmentBuilder, createHeader } from '../../common/nodes.js';
 import { SystemModelIndex } from './system-model-index.js';
@@ -17,7 +17,7 @@ export class GEntityNode extends GNode {
 }
 
 export class GEntityNodeBuilder extends GNodeBuilder<GEntityNode> {
-   set(node: EntityNode, index: SystemModelIndex): this {
+   set(node: LogicalEntityNode, index: SystemModelIndex): this {
       this.id(index.createId(node));
 
       // Get the reference that the DiagramNode holds to the Entity in the .langium file.
@@ -25,7 +25,7 @@ export class GEntityNodeBuilder extends GNodeBuilder<GEntityNode> {
 
       // Options which are the same for every node
       this.addCssClasses('diagram-node', 'entity');
-      this.addArg(REFERENCE_CONTAINER_TYPE, EntityNode);
+      this.addArg(REFERENCE_CONTAINER_TYPE, LogicalEntityNode);
       this.addArg(REFERENCE_PROPERTY, 'entity');
       this.addArg(REFERENCE_VALUE, node.entity.$refText);
 

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-diagram-gmodel-factory.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-diagram-gmodel-factory.ts
@@ -3,7 +3,7 @@
  ********************************************************************************/
 import { GEdge, GGraph, GModelFactory, GNode, ModelState } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
-import { EntityNode, InheritanceEdge, RelationshipEdge, isRelationshipEdge } from '../../../language-server/generated/ast.js';
+import { InheritanceEdge, LogicalEntityNode, RelationshipEdge, isRelationshipEdge } from '../../../language-server/generated/ast.js';
 import { GInheritanceEdge, GRelationshipEdge } from './edges.js';
 import { GEntityNode } from './nodes.js';
 import { SystemModelState } from './system-model-state.js';
@@ -45,7 +45,7 @@ export class SystemDiagramGModelFactory implements GModelFactory {
       return graphBuilder.build();
    }
 
-   protected createEntityNode(node: EntityNode): GNode {
+   protected createEntityNode(node: LogicalEntityNode): GNode {
       return GEntityNode.builder().set(node, this.modelState.index).build();
    }
 

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-model-index.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/model/system-model-index.ts
@@ -4,14 +4,14 @@
 import { injectable } from 'inversify';
 import { AstNode } from 'langium';
 import {
-   Entity,
-   EntityNode,
    InheritanceEdge,
+   LogicalEntity,
+   LogicalEntityNode,
    Relationship,
    RelationshipEdge,
-   isEntity,
-   isEntityNode,
    isInheritanceEdge,
+   isLogicalEntity,
+   isLogicalEntityNode,
    isRelationship,
    isRelationshipEdge
 } from '../../../language-server/generated/ast.js';
@@ -19,16 +19,16 @@ import { CrossModelIndex } from '../../common/cross-model-index.js';
 
 @injectable()
 export class SystemModelIndex extends CrossModelIndex {
-   findEntity(id: string): Entity | undefined {
-      return this.findSemanticElement(id, isEntity);
+   findLogicalEntity(id: string): LogicalEntity | undefined {
+      return this.findSemanticElement(id, isLogicalEntity);
    }
 
    findRelationship(id: string): Relationship | undefined {
       return this.findSemanticElement(id, isRelationship);
    }
 
-   findEntityNode(id: string): EntityNode | undefined {
-      return this.findSemanticElement(id, isEntityNode);
+   findLogicalEntityNode(id: string): LogicalEntityNode | undefined {
+      return this.findSemanticElement(id, isLogicalEntityNode);
    }
 
    findRelationshipEdge(id: string): RelationshipEdge | undefined {
@@ -41,7 +41,7 @@ export class SystemModelIndex extends CrossModelIndex {
 
    protected override indexAstNode(node: AstNode): void {
       super.indexAstNode(node);
-      if (isEntityNode(node)) {
+      if (isLogicalEntityNode(node)) {
          this.indexSemanticElement(`${this.createId(node)}_label`, node);
       }
    }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-module.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/system-diagram-module.ts
@@ -61,7 +61,7 @@ export class SystemDiagramModule extends DiagramModule {
    protected override configureOperationHandlers(binding: InstanceMultiBinding<OperationHandlerConstructor>): void {
       super.configureOperationHandlers(binding);
       binding.add(SystemDiagramChangeBoundsOperationHandler); // move + resize behavior
-      binding.add(SystemDiagramCreateRelationshipOperationHandler); // create 1:1 relationship
+      binding.add(SystemDiagramCreateRelationshipOperationHandler); // create relationship
       binding.add(SystemDiagramDeleteOperationHandler); // delete elements
       binding.add(SystemDiagramDropEntityOperationHandler);
       binding.add(SystemDiagramAddEntityOperationHandler);

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/tool-palette/system-tool-palette-provider.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/tool-palette/system-tool-palette-provider.ts
@@ -54,13 +54,13 @@ export class SystemToolPaletteProvider extends ToolPaletteItemProvider {
                   id: 'entity-create-tool',
                   sortString: '4',
                   label: 'Create Entity',
-                  icon: ModelStructure.Entity.ICON,
+                  icon: ModelStructure.LogicalEntity.ICON,
                   actions: [TriggerNodeCreationAction.create(ENTITY_NODE_TYPE, { args: { type: 'create' } })]
                },
                {
                   id: 'relationship-create-tool',
                   sortString: '5',
-                  label: 'Create 1:1 Relationship',
+                  label: 'Create Relationship',
                   icon: ModelStructure.Relationship.ICON,
                   actions: [TriggerEdgeCreationAction.create(RELATIONSHIP_EDGE_TYPE)]
                },

--- a/extensions/crossmodel-lang/src/language-server/cross-model-scope.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-scope.ts
@@ -8,14 +8,14 @@ import { CrossModelServices } from './cross-model-module.js';
 import { DefaultIdProvider, combineIds } from './cross-model-naming.js';
 import { CrossModelPackageManager, UNKNOWN_PROJECT_ID, UNKNOWN_PROJECT_REFERENCE } from './cross-model-package-manager.js';
 import {
-   Entity,
-   EntityNode,
-   EntityNodeAttribute,
+   LogicalEntity,
+   LogicalEntityNode,
+   LogicalEntityNodeAttribute,
    SourceObject,
    SourceObjectAttribute,
    TargetObject,
    TargetObjectAttribute,
-   isEntityNode,
+   isLogicalEntityNode,
    isSourceObject,
    isTargetObject
 } from './generated/ast.js';
@@ -118,14 +118,14 @@ export class CrossModelScopeComputation extends DefaultScopeComputation {
          const id = this.idProvider.getNodeId(node);
          if (id) {
             scopes.add(container, this.descriptions.createDescription(node, id, document));
-            if (isEntityNode(node)) {
+            if (isLogicalEntityNode(node)) {
                this.processEntityNode(node, id, document).forEach(description => scopes.add(container, description));
             } else if (isSourceObject(node)) {
                this.processSourceObject(node, id, document).forEach(description => scopes.add(container, description));
             }
          }
          if (isTargetObject(node)) {
-            const entity = this.getEntity(node, document);
+            const entity = this.getLogicalEntity(node, document);
             if (entity?.id) {
                this.processTargetObject(node, entity.id, document).forEach(description => scopes.add(container, description));
             }
@@ -133,18 +133,20 @@ export class CrossModelScopeComputation extends DefaultScopeComputation {
       }
    }
 
-   protected processEntityNode(node: EntityNode, nodeId: string, document: LangiumDocument): AstNodeDescription[] {
-      const entity = this.getEntity(node, document);
+   protected processEntityNode(node: LogicalEntityNode, nodeId: string, document: LangiumDocument): AstNodeDescription[] {
+      const entity = this.getLogicalEntity(node, document);
       if (!entity) {
          return [];
       }
       const attributes =
-         entity.attributes.map<EntityNodeAttribute>(attribute => setOwner({ ...attribute, $type: EntityNodeAttribute }, node)) ?? [];
+         entity.attributes.map<LogicalEntityNodeAttribute>(attribute =>
+            setOwner({ ...attribute, $type: LogicalEntityNodeAttribute }, node)
+         ) ?? [];
       setAttributes(node, attributes);
       return attributes.map(attribute => this.descriptions.createDescription(attribute, combineIds(nodeId, attribute.id), document));
    }
 
-   protected getEntity(node: AstNode & { entity: Reference<Entity> }, document: LangiumDocument): Entity | undefined {
+   protected getLogicalEntity(node: AstNode & { entity: Reference<LogicalEntity> }, document: LangiumDocument): LogicalEntity | undefined {
       try {
          return fixDocument(node, document).entity?.ref;
       } catch (error) {
@@ -154,7 +156,7 @@ export class CrossModelScopeComputation extends DefaultScopeComputation {
    }
 
    protected processSourceObject(node: SourceObject, nodeId: string, document: LangiumDocument): AstNodeDescription[] {
-      const entity = this.getEntity(node, document);
+      const entity = this.getLogicalEntity(node, document);
       if (!entity) {
          return [];
       }
@@ -165,7 +167,7 @@ export class CrossModelScopeComputation extends DefaultScopeComputation {
    }
 
    protected processTargetObject(node: TargetObject, nodeId: string, document: LangiumDocument): AstNodeDescription[] {
-      const entity = this.getEntity(node, document);
+      const entity = this.getLogicalEntity(node, document);
       if (!entity) {
          return [];
       }

--- a/extensions/crossmodel-lang/src/language-server/cross-model-serializer.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-serializer.ts
@@ -9,8 +9,6 @@ import { Serializer } from '../model-server/serializer.js';
 import {
    AttributeMapping,
    CrossModelRoot,
-   Entity,
-   EntityNode,
    isAttributeMappingSource,
    isAttributeMappingTarget,
    isCustomProperty,
@@ -21,6 +19,8 @@ import {
    isSourceObjectDependency,
    JoinCondition,
    LogicalAttribute,
+   LogicalEntity,
+   LogicalEntityNode,
    Mapping,
    reflection,
    Relationship,
@@ -45,7 +45,7 @@ const CUSTOM_PROPERTIES = ['customProperties'];
  * It cannot be derived for interfaces as the interface order does not reflect property order in grammar due to inheritance.
  */
 const PROPERTY_ORDER = new Map<string, string[]>([
-   [Entity, [...NAMED_OBJECT_PROPERTIES, 'superEntities', 'attributes', ...CUSTOM_PROPERTIES]],
+   [LogicalEntity, [...NAMED_OBJECT_PROPERTIES, 'superEntities', 'attributes', ...CUSTOM_PROPERTIES]],
    [LogicalAttribute, [...NAMED_OBJECT_PROPERTIES, 'datatype', 'length', 'precision', 'scale', 'identifier', ...CUSTOM_PROPERTIES]],
    [
       Relationship,
@@ -63,7 +63,7 @@ const PROPERTY_ORDER = new Map<string, string[]>([
    ],
    [RelationshipAttribute, ['parent', 'child', ...CUSTOM_PROPERTIES]],
    [SystemDiagram, [...IDENTIFIED_PROPERTIES, 'nodes', 'edges']],
-   [EntityNode, [...IDENTIFIED_PROPERTIES, 'entity', 'x', 'y', 'width', 'height']],
+   [LogicalEntityNode, [...IDENTIFIED_PROPERTIES, 'entity', 'x', 'y', 'width', 'height']],
    [RelationshipEdge, [...IDENTIFIED_PROPERTIES, 'relationship', 'sourceNode', 'targetNode']],
    [Mapping, [...IDENTIFIED_PROPERTIES, 'sources', 'target', ...CUSTOM_PROPERTIES]],
    [SourceObject, [...IDENTIFIED_PROPERTIES, 'entity', 'join', 'dependencies', 'conditions', ...CUSTOM_PROPERTIES]],

--- a/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
@@ -17,15 +17,15 @@ import { ID_PROPERTY, IdentifiableAstNode } from './cross-model-naming.js';
 import {
    AttributeMapping,
    CrossModelAstType,
-   Entity,
    InheritanceEdge,
    isCrossModelRoot,
-   isEntity,
    isLogicalAttribute,
+   isLogicalEntity,
    isMapping,
    isRelationship,
    isSystemDiagram,
    LogicalAttribute,
+   LogicalEntity,
    Mapping,
    NamedObject,
    Relationship,
@@ -65,7 +65,7 @@ export function registerValidationChecks(services: CrossModelServices): void {
    const checks: ValidationChecks<CrossModelAstType> = {
       AstNode: validator.checkNode,
       AttributeMapping: validator.checkAttributeMapping,
-      Entity: validator.checkEntity,
+      LogicalEntity: validator.checkLogicalEntity,
       Mapping: validator.checkMapping,
       Relationship: validator.checkRelationship,
       RelationshipEdge: validator.checkRelationshipEdge,
@@ -140,7 +140,7 @@ export class CrossModelValidator {
 
    protected isExportedGlobally(node: AstNode): boolean {
       // we export anything with an id from entities and relationships and all root nodes, see CrossModelScopeComputation
-      return isEntity(node) || isLogicalAttribute(node) || isRelationship(node) || isSystemDiagram(node) || isMapping(node);
+      return isLogicalEntity(node) || isLogicalAttribute(node) || isRelationship(node) || isSystemDiagram(node) || isMapping(node);
    }
 
    protected checkUniqueNodeId(node: AstNode, accept: ValidationAcceptor): void {
@@ -181,19 +181,19 @@ export class CrossModelValidator {
       }
    }
 
-   checkEntity(entity: Entity, accept: ValidationAcceptor): void {
+   checkLogicalEntity(entity: LogicalEntity, accept: ValidationAcceptor): void {
       const cycle = this.findInheritanceCycle(entity);
       if (cycle.length > 0) {
          accept('error', `Inheritance cycle detected: ${cycle.join(' -> ')}.`, { node: entity, property: 'superEntities' });
       }
    }
 
-   protected findInheritanceCycle(entity: Entity): string[] {
+   protected findInheritanceCycle(entity: LogicalEntity): string[] {
       const visited: Set<string> = new Set();
       const recursionStack: Set<string> = new Set();
       const path: string[] = [];
 
-      function depthFirst(current: Entity): string[] {
+      function depthFirst(current: LogicalEntity): string[] {
          const currentId = current.id;
 
          // Mark the current node as visited and add to recursion stack

--- a/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
@@ -182,6 +182,15 @@ export class CrossModelValidator {
    }
 
    checkLogicalEntity(entity: LogicalEntity, accept: ValidationAcceptor): void {
+      // Check that there is only one primary identifier
+      const primaryIdentifiers = entity.identifiers.filter(identifier => identifier.primary === true);
+      if (primaryIdentifiers.length > 1) {
+         accept('error', `${primaryIdentifiers.length} primary identifiers defined, there should only be 1.`, {
+            node: entity,
+            property: 'identifiers'
+         });
+      }
+
       const cycle = this.findInheritanceCycle(entity);
       if (cycle.length > 0) {
          accept('error', `Inheritance cycle detected: ${cycle.join(' -> ')}.`, { node: entity, property: 'superEntities' });

--- a/extensions/crossmodel-lang/src/language-server/generated/ast.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/ast.ts
@@ -158,7 +158,7 @@ export function isBinaryExpression(item: unknown): item is BinaryExpression {
 
 export interface CrossModelRoot extends AstNode {
     readonly $type: 'CrossModelRoot';
-    entity?: Entity;
+    entity?: LogicalEntity;
     mapping?: Mapping;
     relationship?: Relationship;
     systemDiagram?: SystemDiagram;
@@ -184,7 +184,7 @@ export function isCustomProperty(item: unknown): item is CustomProperty {
 }
 
 export interface IdentifiedObject extends AstNode {
-    readonly $type: 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'DataElementContainerMapping' | 'DataElementMapping' | 'Entity' | 'EntityNode' | 'EntityNodeAttribute' | 'IdentifiedObject' | 'InheritanceEdge' | 'LogicalAttribute' | 'Mapping' | 'NamedObject' | 'Relationship' | 'RelationshipEdge' | 'SourceDataElementContainer' | 'SourceObject' | 'SourceObjectAttribute' | 'SystemDiagram' | 'SystemDiagramEdge' | 'TargetObjectAttribute';
+    readonly $type: 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'DataElementContainerMapping' | 'DataElementMapping' | 'IdentifiedObject' | 'InheritanceEdge' | 'LogicalAttribute' | 'LogicalEntity' | 'LogicalEntityNode' | 'LogicalEntityNodeAttribute' | 'Mapping' | 'NamedObject' | 'Relationship' | 'RelationshipEdge' | 'SourceDataElementContainer' | 'SourceObject' | 'SourceObjectAttribute' | 'SystemDiagram' | 'SystemDiagramEdge' | 'TargetObjectAttribute';
     id: string;
 }
 
@@ -255,7 +255,7 @@ export function isStringLiteral(item: unknown): item is StringLiteral {
 }
 
 export interface WithCustomProperties extends AstNode {
-    readonly $type: 'AttributeMapping' | 'Entity' | 'EntityNodeAttribute' | 'LogicalAttribute' | 'Mapping' | 'Relationship' | 'RelationshipAttribute' | 'SourceObject' | 'SourceObjectAttribute' | 'TargetObject' | 'TargetObjectAttribute' | 'WithCustomProperties';
+    readonly $type: 'AttributeMapping' | 'LogicalAttribute' | 'LogicalEntity' | 'LogicalEntityNodeAttribute' | 'Mapping' | 'Relationship' | 'RelationshipAttribute' | 'SourceObject' | 'SourceObjectAttribute' | 'TargetObject' | 'TargetObjectAttribute' | 'WithCustomProperties';
     customProperties: Array<CustomProperty>;
 }
 
@@ -286,24 +286,24 @@ export function isDataElementMapping(item: unknown): item is DataElementMapping 
     return reflection.isInstance(item, DataElementMapping);
 }
 
-export interface EntityNode extends IdentifiedObject {
+export interface LogicalEntityNode extends IdentifiedObject {
     readonly $container: SystemDiagram;
-    readonly $type: 'EntityNode';
-    entity: Reference<Entity>;
+    readonly $type: 'LogicalEntityNode';
+    entity: Reference<LogicalEntity>;
     height: number;
     width: number;
     x: number;
     y: number;
 }
 
-export const EntityNode = 'EntityNode';
+export const LogicalEntityNode = 'LogicalEntityNode';
 
-export function isEntityNode(item: unknown): item is EntityNode {
-    return reflection.isInstance(item, EntityNode);
+export function isLogicalEntityNode(item: unknown): item is LogicalEntityNode {
+    return reflection.isInstance(item, LogicalEntityNode);
 }
 
 export interface NamedObject extends IdentifiedObject {
-    readonly $type: 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'Entity' | 'EntityNodeAttribute' | 'LogicalAttribute' | 'NamedObject' | 'Relationship' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
+    readonly $type: 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'LogicalAttribute' | 'LogicalEntity' | 'LogicalEntityNodeAttribute' | 'NamedObject' | 'Relationship' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
     description?: string;
     name: string;
 }
@@ -329,7 +329,7 @@ export interface SystemDiagram extends IdentifiedObject {
     readonly $container: CrossModelRoot;
     readonly $type: 'SystemDiagram';
     edges: Array<SystemDiagramEdge>;
-    nodes: Array<EntityNode>;
+    nodes: Array<LogicalEntityNode>;
 }
 
 export const SystemDiagram = 'SystemDiagram';
@@ -362,21 +362,8 @@ export function isAttributeMapping(item: unknown): item is AttributeMapping {
     return reflection.isInstance(item, AttributeMapping);
 }
 
-export interface Entity extends DataElementContainer, WithCustomProperties {
-    readonly $container: CrossModelRoot;
-    readonly $type: 'Entity';
-    attributes: Array<LogicalAttribute>;
-    superEntities: Array<Reference<Entity>>;
-}
-
-export const Entity = 'Entity';
-
-export function isEntity(item: unknown): item is Entity {
-    return reflection.isInstance(item, Entity);
-}
-
 export interface LogicalAttribute extends DataElement, WithCustomProperties {
-    readonly $type: 'EntityNodeAttribute' | 'LogicalAttribute' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
+    readonly $type: 'LogicalAttribute' | 'LogicalEntityNodeAttribute' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
     identifier: boolean;
     length?: number;
     precision?: number;
@@ -387,6 +374,19 @@ export const LogicalAttribute = 'LogicalAttribute';
 
 export function isLogicalAttribute(item: unknown): item is LogicalAttribute {
     return reflection.isInstance(item, LogicalAttribute);
+}
+
+export interface LogicalEntity extends DataElementContainer, WithCustomProperties {
+    readonly $container: CrossModelRoot;
+    readonly $type: 'LogicalEntity';
+    attributes: Array<LogicalAttribute>;
+    superEntities: Array<Reference<LogicalEntity>>;
+}
+
+export const LogicalEntity = 'LogicalEntity';
+
+export function isLogicalEntity(item: unknown): item is LogicalEntity {
+    return reflection.isInstance(item, LogicalEntity);
 }
 
 export interface Mapping extends DataElementContainerMapping, WithCustomProperties {
@@ -406,10 +406,10 @@ export interface Relationship extends DataElementContainerLink, WithCustomProper
     readonly $container: CrossModelRoot;
     readonly $type: 'Relationship';
     attributes: Array<RelationshipAttribute>;
-    child: Reference<Entity>;
+    child: Reference<LogicalEntity>;
     childCardinality?: string;
     childRole?: string;
-    parent: Reference<Entity>;
+    parent: Reference<LogicalEntity>;
     parentCardinality?: string;
     parentRole?: string;
 }
@@ -438,7 +438,7 @@ export interface SourceObject extends SourceDataElementContainer, WithCustomProp
     readonly $type: 'SourceObject';
     conditions: Array<SourceObjectCondition>;
     dependencies: Array<SourceObjectDependency>;
-    entity: Reference<Entity>;
+    entity: Reference<LogicalEntity>;
     join: string;
 }
 
@@ -451,7 +451,7 @@ export function isSourceObject(item: unknown): item is SourceObject {
 export interface TargetObject extends WithCustomProperties {
     readonly $container: Mapping;
     readonly $type: 'TargetObject';
-    entity: Reference<Entity>;
+    entity: Reference<LogicalEntity>;
     mappings: Array<AttributeMapping>;
 }
 
@@ -462,7 +462,7 @@ export function isTargetObject(item: unknown): item is TargetObject {
 }
 
 export interface DataElement extends NamedObject {
-    readonly $type: 'DataElement' | 'EntityNodeAttribute' | 'LogicalAttribute' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
+    readonly $type: 'DataElement' | 'LogicalAttribute' | 'LogicalEntityNodeAttribute' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
     datatype?: string;
 }
 
@@ -474,7 +474,7 @@ export function isDataElement(item: unknown): item is DataElement {
 
 export interface DataElementContainer extends NamedObject {
     readonly $container: CrossModelRoot;
-    readonly $type: 'DataElementContainer' | 'Entity';
+    readonly $type: 'DataElementContainer' | 'LogicalEntity';
 }
 
 export const DataElementContainer = 'DataElementContainer';
@@ -496,8 +496,8 @@ export function isDataElementContainerLink(item: unknown): item is DataElementCo
 
 export interface InheritanceEdge extends SystemDiagramEdge {
     readonly $type: 'InheritanceEdge';
-    baseNode: Reference<EntityNode>;
-    superNode: Reference<EntityNode>;
+    baseNode: Reference<LogicalEntityNode>;
+    superNode: Reference<LogicalEntityNode>;
 }
 
 export const InheritanceEdge = 'InheritanceEdge';
@@ -509,8 +509,8 @@ export function isInheritanceEdge(item: unknown): item is InheritanceEdge {
 export interface RelationshipEdge extends SystemDiagramEdge {
     readonly $type: 'RelationshipEdge';
     relationship: Reference<Relationship>;
-    sourceNode: Reference<EntityNode>;
-    targetNode: Reference<EntityNode>;
+    sourceNode: Reference<LogicalEntityNode>;
+    targetNode: Reference<LogicalEntityNode>;
 }
 
 export const RelationshipEdge = 'RelationshipEdge';
@@ -519,14 +519,14 @@ export function isRelationshipEdge(item: unknown): item is RelationshipEdge {
     return reflection.isInstance(item, RelationshipEdge);
 }
 
-export interface EntityNodeAttribute extends LogicalAttribute {
-    readonly $type: 'EntityNodeAttribute';
+export interface LogicalEntityNodeAttribute extends LogicalAttribute {
+    readonly $type: 'LogicalEntityNodeAttribute';
 }
 
-export const EntityNodeAttribute = 'EntityNodeAttribute';
+export const LogicalEntityNodeAttribute = 'LogicalEntityNodeAttribute';
 
-export function isEntityNodeAttribute(item: unknown): item is EntityNodeAttribute {
-    return reflection.isInstance(item, EntityNodeAttribute);
+export function isLogicalEntityNodeAttribute(item: unknown): item is LogicalEntityNodeAttribute {
+    return reflection.isInstance(item, LogicalEntityNodeAttribute);
 }
 
 export interface SourceObjectAttribute extends LogicalAttribute {
@@ -562,13 +562,13 @@ export type CrossModelAstType = {
     DataElementContainerLink: DataElementContainerLink
     DataElementContainerMapping: DataElementContainerMapping
     DataElementMapping: DataElementMapping
-    Entity: Entity
-    EntityNode: EntityNode
-    EntityNodeAttribute: EntityNodeAttribute
     IdentifiedObject: IdentifiedObject
     InheritanceEdge: InheritanceEdge
     JoinCondition: JoinCondition
     LogicalAttribute: LogicalAttribute
+    LogicalEntity: LogicalEntity
+    LogicalEntityNode: LogicalEntityNode
+    LogicalEntityNodeAttribute: LogicalEntityNodeAttribute
     Mapping: Mapping
     NamedObject: NamedObject
     NumberLiteral: NumberLiteral
@@ -592,7 +592,7 @@ export type CrossModelAstType = {
 export class CrossModelAstReflection extends AbstractAstReflection {
 
     getAllTypes(): string[] {
-        return [AttributeMapping, AttributeMappingSource, AttributeMappingTarget, BinaryExpression, BooleanExpression, CrossModelRoot, CustomProperty, DataElement, DataElementContainer, DataElementContainerLink, DataElementContainerMapping, DataElementMapping, Entity, EntityNode, EntityNodeAttribute, IdentifiedObject, InheritanceEdge, JoinCondition, LogicalAttribute, Mapping, NamedObject, NumberLiteral, Relationship, RelationshipAttribute, RelationshipEdge, SourceDataElementContainer, SourceObject, SourceObjectAttribute, SourceObjectAttributeReference, SourceObjectCondition, SourceObjectDependency, StringLiteral, SystemDiagram, SystemDiagramEdge, TargetObject, TargetObjectAttribute, WithCustomProperties];
+        return [AttributeMapping, AttributeMappingSource, AttributeMappingTarget, BinaryExpression, BooleanExpression, CrossModelRoot, CustomProperty, DataElement, DataElementContainer, DataElementContainerLink, DataElementContainerMapping, DataElementMapping, IdentifiedObject, InheritanceEdge, JoinCondition, LogicalAttribute, LogicalEntity, LogicalEntityNode, LogicalEntityNodeAttribute, Mapping, NamedObject, NumberLiteral, Relationship, RelationshipAttribute, RelationshipEdge, SourceDataElementContainer, SourceObject, SourceObjectAttribute, SourceObjectAttributeReference, SourceObjectCondition, SourceObjectDependency, StringLiteral, SystemDiagram, SystemDiagramEdge, TargetObject, TargetObjectAttribute, WithCustomProperties];
     }
 
     protected override computeIsSubtype(subtype: string, supertype: string): boolean {
@@ -609,20 +609,12 @@ export class CrossModelAstReflection extends AbstractAstReflection {
             }
             case DataElementContainerMapping:
             case DataElementMapping:
-            case EntityNode:
+            case LogicalEntityNode:
             case NamedObject:
             case SourceDataElementContainer:
             case SystemDiagram:
             case SystemDiagramEdge: {
                 return this.isSubtype(IdentifiedObject, supertype);
-            }
-            case Entity: {
-                return this.isSubtype(DataElementContainer, supertype) || this.isSubtype(WithCustomProperties, supertype);
-            }
-            case EntityNodeAttribute:
-            case SourceObjectAttribute:
-            case TargetObjectAttribute: {
-                return this.isSubtype(LogicalAttribute, supertype);
             }
             case InheritanceEdge:
             case RelationshipEdge: {
@@ -633,6 +625,14 @@ export class CrossModelAstReflection extends AbstractAstReflection {
             }
             case LogicalAttribute: {
                 return this.isSubtype(DataElement, supertype) || this.isSubtype(WithCustomProperties, supertype);
+            }
+            case LogicalEntity: {
+                return this.isSubtype(DataElementContainer, supertype) || this.isSubtype(WithCustomProperties, supertype);
+            }
+            case LogicalEntityNodeAttribute:
+            case SourceObjectAttribute:
+            case TargetObjectAttribute: {
+                return this.isSubtype(LogicalAttribute, supertype);
             }
             case Mapping: {
                 return this.isSubtype(DataElementContainerMapping, supertype) || this.isSubtype(WithCustomProperties, supertype);
@@ -664,19 +664,19 @@ export class CrossModelAstReflection extends AbstractAstReflection {
             case 'AttributeMappingTarget:value': {
                 return TargetObjectAttribute;
             }
-            case 'Entity:superEntities':
-            case 'EntityNode:entity':
-            case 'Relationship:child':
-            case 'Relationship:parent':
-            case 'SourceObject:entity':
-            case 'TargetObject:entity': {
-                return Entity;
-            }
             case 'InheritanceEdge:baseNode':
             case 'InheritanceEdge:superNode':
             case 'RelationshipEdge:sourceNode':
             case 'RelationshipEdge:targetNode': {
-                return EntityNode;
+                return LogicalEntityNode;
+            }
+            case 'LogicalEntity:superEntities':
+            case 'LogicalEntityNode:entity':
+            case 'Relationship:child':
+            case 'Relationship:parent':
+            case 'SourceObject:entity':
+            case 'TargetObject:entity': {
+                return LogicalEntity;
             }
             case 'RelationshipAttribute:child':
             case 'RelationshipAttribute:parent': {
@@ -814,9 +814,9 @@ export class CrossModelAstReflection extends AbstractAstReflection {
                     ]
                 };
             }
-            case EntityNode: {
+            case LogicalEntityNode: {
                 return {
-                    name: EntityNode,
+                    name: LogicalEntityNode,
                     properties: [
                         { name: 'entity' },
                         { name: 'height' },
@@ -874,19 +874,6 @@ export class CrossModelAstReflection extends AbstractAstReflection {
                     ]
                 };
             }
-            case Entity: {
-                return {
-                    name: Entity,
-                    properties: [
-                        { name: 'attributes', defaultValue: [] },
-                        { name: 'customProperties', defaultValue: [] },
-                        { name: 'description' },
-                        { name: 'id' },
-                        { name: 'name' },
-                        { name: 'superEntities', defaultValue: [] }
-                    ]
-                };
-            }
             case LogicalAttribute: {
                 return {
                     name: LogicalAttribute,
@@ -900,6 +887,19 @@ export class CrossModelAstReflection extends AbstractAstReflection {
                         { name: 'name' },
                         { name: 'precision' },
                         { name: 'scale' }
+                    ]
+                };
+            }
+            case LogicalEntity: {
+                return {
+                    name: LogicalEntity,
+                    properties: [
+                        { name: 'attributes', defaultValue: [] },
+                        { name: 'customProperties', defaultValue: [] },
+                        { name: 'description' },
+                        { name: 'id' },
+                        { name: 'name' },
+                        { name: 'superEntities', defaultValue: [] }
                     ]
                 };
             }
@@ -1017,9 +1017,9 @@ export class CrossModelAstReflection extends AbstractAstReflection {
                     ]
                 };
             }
-            case EntityNodeAttribute: {
+            case LogicalEntityNodeAttribute: {
                 return {
-                    name: EntityNodeAttribute,
+                    name: LogicalEntityNodeAttribute,
                     properties: [
                         { name: 'customProperties', defaultValue: [] },
                         { name: 'datatype' },

--- a/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
@@ -79,7 +79,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
     },
     {
       "$type": "ParserRule",
-      "name": "Entity",
+      "name": "LogicalEntity",
       "returnType": {
         "$ref": "#/interfaces@0"
       },
@@ -1330,7 +1330,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
     },
     {
       "$type": "ParserRule",
-      "name": "EntityNode",
+      "name": "LogicalEntityNode",
       "returnType": {
         "$ref": "#/interfaces@14"
       },
@@ -2588,7 +2588,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
   "interfaces": [
     {
       "$type": "Interface",
-      "name": "Entity",
+      "name": "LogicalEntity",
       "superTypes": [
         {
           "$ref": "#/interfaces@4"
@@ -2989,7 +2989,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
     },
     {
       "$type": "Interface",
-      "name": "EntityNode",
+      "name": "LogicalEntityNode",
       "superTypes": [
         {
           "$ref": "#/interfaces@2"
@@ -3050,7 +3050,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
     },
     {
       "$type": "Interface",
-      "name": "EntityNodeAttribute",
+      "name": "LogicalEntityNodeAttribute",
       "superTypes": [
         {
           "$ref": "#/interfaces@1"

--- a/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
@@ -39,7 +39,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@18"
+                "$ref": "#/rules@19"
               },
               "arguments": []
             }
@@ -51,7 +51,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@20"
+                "$ref": "#/rules@21"
               },
               "arguments": []
             }
@@ -63,7 +63,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@25"
+                "$ref": "#/rules@26"
               },
               "arguments": []
             }
@@ -97,14 +97,14 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@8"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@14"
+              "$ref": "#/rules@15"
             },
             "arguments": []
           },
@@ -122,7 +122,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -132,7 +132,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -148,7 +148,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                       "terminal": {
                         "$type": "RuleCall",
                         "rule": {
-                          "$ref": "#/rules@6"
+                          "$ref": "#/rules@7"
                         },
                         "arguments": []
                       },
@@ -161,7 +161,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -182,7 +182,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -192,7 +192,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -214,7 +214,60 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
+                  "$ref": "#/rules@10"
+                },
+                "arguments": []
+              }
+            ],
+            "cardinality": "?"
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "identifiers"
+              },
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "RuleCall",
+                "rule": {
                   "$ref": "#/rules@9"
+                },
+                "arguments": []
+              },
+              {
+                "$type": "Group",
+                "elements": [
+                  {
+                    "$type": "RuleCall",
+                    "rule": {
+                      "$ref": "#/rules@11"
+                    },
+                    "arguments": []
+                  },
+                  {
+                    "$type": "Assignment",
+                    "feature": "identifiers",
+                    "operator": "+=",
+                    "terminal": {
+                      "$type": "RuleCall",
+                      "rule": {
+                        "$ref": "#/rules@3"
+                      },
+                      "arguments": []
+                    }
+                  }
+                ],
+                "cardinality": "+"
+              },
+              {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -224,7 +277,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -232,7 +285,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           }
@@ -257,7 +310,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@14"
+              "$ref": "#/rules@15"
             },
             "arguments": []
           },
@@ -279,7 +332,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@3"
+                    "$ref": "#/rules@4"
                   },
                   "arguments": []
                 }
@@ -305,7 +358,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@4"
+                    "$ref": "#/rules@5"
                   },
                   "arguments": []
                 }
@@ -331,7 +384,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@4"
+                    "$ref": "#/rules@5"
                   },
                   "arguments": []
                 }
@@ -357,7 +410,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@4"
+                    "$ref": "#/rules@5"
                   },
                   "arguments": []
                 }
@@ -400,7 +453,132 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
+              "$ref": "#/rules@16"
+            },
+            "arguments": [],
+            "cardinality": "?"
+          }
+        ]
+      },
+      "definesHiddenTokens": false,
+      "entry": false,
+      "fragment": false,
+      "hiddenTokens": [],
+      "parameters": [],
+      "wildcard": false
+    },
+    {
+      "$type": "ParserRule",
+      "name": "LogicalIdentifier",
+      "returnType": {
+        "$ref": "#/interfaces@2"
+      },
+      "definition": {
+        "$type": "Group",
+        "elements": [
+          {
+            "$type": "RuleCall",
+            "rule": {
               "$ref": "#/rules@15"
+            },
+            "arguments": []
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Assignment",
+                "feature": "primary",
+                "operator": "?=",
+                "terminal": {
+                  "$type": "Keyword",
+                  "value": "primary"
+                }
+              },
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "Alternatives",
+                "elements": [
+                  {
+                    "$type": "Keyword",
+                    "value": "TRUE"
+                  },
+                  {
+                    "$type": "Keyword",
+                    "value": "true"
+                  }
+                ]
+              }
+            ],
+            "cardinality": "?"
+          },
+          {
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "attributes"
+              },
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@9"
+                },
+                "arguments": []
+              },
+              {
+                "$type": "Group",
+                "elements": [
+                  {
+                    "$type": "RuleCall",
+                    "rule": {
+                      "$ref": "#/rules@11"
+                    },
+                    "arguments": []
+                  },
+                  {
+                    "$type": "Assignment",
+                    "feature": "attributes",
+                    "operator": "+=",
+                    "terminal": {
+                      "$type": "CrossReference",
+                      "type": {
+                        "$ref": "#/interfaces@1"
+                      },
+                      "terminal": {
+                        "$type": "RuleCall",
+                        "rule": {
+                          "$ref": "#/rules@7"
+                        },
+                        "arguments": []
+                      },
+                      "deprecatedSyntax": false
+                    }
+                  }
+                ],
+                "cardinality": "+"
+              },
+              {
+                "$type": "RuleCall",
+                "rule": {
+                  "$ref": "#/rules@10"
+                },
+                "arguments": []
+              }
+            ],
+            "cardinality": "?"
+          },
+          {
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -458,7 +636,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@5"
+              "$ref": "#/rules@6"
             },
             "arguments": []
           },
@@ -472,7 +650,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@5"
+                  "$ref": "#/rules@6"
                 },
                 "arguments": []
               }
@@ -562,7 +740,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "IdentifiedObjectFragment",
       "fragment": true,
       "returnType": {
-        "$ref": "#/interfaces@2"
+        "$ref": "#/interfaces@3"
       },
       "definition": {
         "$type": "Group",
@@ -582,7 +760,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@5"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -600,7 +778,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "NamedObjectFragment",
       "fragment": true,
       "returnType": {
-        "$ref": "#/interfaces@3"
+        "$ref": "#/interfaces@4"
       },
       "definition": {
         "$type": "Group",
@@ -608,7 +786,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@14"
             },
             "arguments": []
           },
@@ -627,7 +805,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@3"
+                "$ref": "#/rules@4"
               },
               "arguments": []
             }
@@ -650,7 +828,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@3"
+                    "$ref": "#/rules@4"
                   },
                   "arguments": []
                 }
@@ -671,7 +849,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "CustomPropertiesFragment",
       "fragment": true,
       "returnType": {
-        "$ref": "#/interfaces@10"
+        "$ref": "#/interfaces@11"
       },
       "definition": {
         "$type": "Group",
@@ -687,7 +865,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@8"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
@@ -697,7 +875,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@10"
+                  "$ref": "#/rules@11"
                 },
                 "arguments": []
               },
@@ -708,7 +886,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@16"
+                    "$ref": "#/rules@17"
                   },
                   "arguments": []
                 }
@@ -719,7 +897,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           }
@@ -752,7 +930,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@5"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -775,7 +953,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@3"
+                    "$ref": "#/rules@4"
                   },
                   "arguments": []
                 }
@@ -824,7 +1002,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "Relationship",
       "returnType": {
-        "$ref": "#/interfaces@11"
+        "$ref": "#/interfaces@12"
       },
       "definition": {
         "$type": "Group",
@@ -840,14 +1018,14 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@8"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@14"
+              "$ref": "#/rules@15"
             },
             "arguments": []
           },
@@ -871,7 +1049,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -896,7 +1074,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@3"
+                    "$ref": "#/rules@4"
                   },
                   "arguments": []
                 }
@@ -922,7 +1100,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@17"
+                    "$ref": "#/rules@18"
                   },
                   "arguments": []
                 }
@@ -950,7 +1128,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -975,7 +1153,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@3"
+                    "$ref": "#/rules@4"
                   },
                   "arguments": []
                 }
@@ -1001,7 +1179,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@17"
+                    "$ref": "#/rules@18"
                   },
                   "arguments": []
                 }
@@ -1023,7 +1201,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -1033,7 +1211,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -1044,7 +1222,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@19"
+                        "$ref": "#/rules@20"
                       },
                       "arguments": []
                     }
@@ -1055,7 +1233,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -1065,7 +1243,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -1073,7 +1251,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           }
@@ -1090,7 +1268,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "RelationshipAttribute",
       "returnType": {
-        "$ref": "#/interfaces@12"
+        "$ref": "#/interfaces@13"
       },
       "definition": {
         "$type": "Group",
@@ -1115,7 +1293,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1142,7 +1320,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1152,7 +1330,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -1170,7 +1348,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "SystemDiagram",
       "returnType": {
-        "$ref": "#/interfaces@13"
+        "$ref": "#/interfaces@14"
       },
       "definition": {
         "$type": "Group",
@@ -1195,14 +1373,14 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@8"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@14"
             },
             "arguments": []
           },
@@ -1220,7 +1398,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -1230,7 +1408,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -1241,7 +1419,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@21"
+                        "$ref": "#/rules@22"
                       },
                       "arguments": []
                     }
@@ -1252,7 +1430,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -1273,7 +1451,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -1283,7 +1461,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -1294,7 +1472,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@22"
+                        "$ref": "#/rules@23"
                       },
                       "arguments": []
                     }
@@ -1305,7 +1483,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -1315,7 +1493,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           }
@@ -1332,7 +1510,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "LogicalEntityNode",
       "returnType": {
-        "$ref": "#/interfaces@14"
+        "$ref": "#/interfaces@15"
       },
       "definition": {
         "$type": "Group",
@@ -1340,7 +1518,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@14"
             },
             "arguments": []
           },
@@ -1364,7 +1542,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1386,7 +1564,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@4"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -1406,7 +1584,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@4"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -1426,7 +1604,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@4"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -1446,7 +1624,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@4"
+                "$ref": "#/rules@5"
               },
               "arguments": []
             }
@@ -1464,7 +1642,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "SystemDiagramEdge",
       "returnType": {
-        "$ref": "#/interfaces@16"
+        "$ref": "#/interfaces@17"
       },
       "definition": {
         "$type": "Alternatives",
@@ -1472,14 +1650,14 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@23"
+              "$ref": "#/rules@24"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@24"
+              "$ref": "#/rules@25"
             },
             "arguments": []
           }
@@ -1496,7 +1674,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "RelationshipEdge",
       "returnType": {
-        "$ref": "#/interfaces@17"
+        "$ref": "#/interfaces@18"
       },
       "definition": {
         "$type": "Group",
@@ -1504,7 +1682,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@14"
             },
             "arguments": []
           },
@@ -1523,12 +1701,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@11"
+                "$ref": "#/interfaces@12"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1550,12 +1728,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1577,12 +1755,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1602,7 +1780,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "InheritanceEdge",
       "returnType": {
-        "$ref": "#/interfaces@18"
+        "$ref": "#/interfaces@19"
       },
       "definition": {
         "$type": "Group",
@@ -1622,7 +1800,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@5"
+                "$ref": "#/rules@6"
               },
               "arguments": []
             }
@@ -1642,12 +1820,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1669,12 +1847,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               },
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1694,7 +1872,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "Mapping",
       "returnType": {
-        "$ref": "#/interfaces@21"
+        "$ref": "#/interfaces@22"
       },
       "definition": {
         "$type": "Group",
@@ -1710,14 +1888,14 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@8"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@14"
             },
             "arguments": []
           },
@@ -1735,7 +1913,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -1745,7 +1923,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -1756,7 +1934,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@26"
+                        "$ref": "#/rules@27"
                       },
                       "arguments": []
                     }
@@ -1767,7 +1945,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -1789,7 +1967,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@33"
+                "$ref": "#/rules@34"
               },
               "arguments": []
             }
@@ -1797,7 +1975,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -1805,7 +1983,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           }
@@ -1822,7 +2000,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "SourceObject",
       "returnType": {
-        "$ref": "#/interfaces@22"
+        "$ref": "#/interfaces@23"
       },
       "definition": {
         "$type": "Group",
@@ -1830,7 +2008,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@13"
+              "$ref": "#/rules@14"
             },
             "arguments": []
           },
@@ -1854,7 +2032,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -1876,7 +2054,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@27"
+                "$ref": "#/rules@28"
               },
               "arguments": []
             }
@@ -1895,7 +2073,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -1905,7 +2083,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -1916,7 +2094,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@28"
+                        "$ref": "#/rules@29"
                       },
                       "arguments": []
                     }
@@ -1927,7 +2105,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -1948,7 +2126,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -1958,7 +2136,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -1969,7 +2147,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@29"
+                        "$ref": "#/rules@30"
                       },
                       "arguments": []
                     }
@@ -1980,7 +2158,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -1990,7 +2168,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -2050,12 +2228,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/interfaces@22"
+            "$ref": "#/interfaces@23"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@6"
+              "$ref": "#/rules@7"
             },
             "arguments": []
           },
@@ -2075,7 +2253,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "definition": {
         "$type": "RuleCall",
         "rule": {
-          "$ref": "#/rules@30"
+          "$ref": "#/rules@31"
         },
         "arguments": []
       },
@@ -2096,7 +2274,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "RuleCall",
           "rule": {
-            "$ref": "#/rules@31"
+            "$ref": "#/rules@32"
           },
           "arguments": []
         }
@@ -2121,7 +2299,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@32"
+                "$ref": "#/rules@33"
               },
               "arguments": []
             }
@@ -2167,7 +2345,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@32"
+                "$ref": "#/rules@33"
               },
               "arguments": []
             }
@@ -2208,7 +2386,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@4"
+                    "$ref": "#/rules@5"
                   },
                   "arguments": []
                 }
@@ -2232,7 +2410,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@3"
+                    "$ref": "#/rules@4"
                   },
                   "arguments": []
                 }
@@ -2256,12 +2434,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/interfaces@19"
+                    "$ref": "#/interfaces@20"
                   },
                   "terminal": {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@6"
+                      "$ref": "#/rules@7"
                     },
                     "arguments": []
                   },
@@ -2283,7 +2461,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "TargetObject",
       "returnType": {
-        "$ref": "#/interfaces@23"
+        "$ref": "#/interfaces@24"
       },
       "definition": {
         "$type": "Group",
@@ -2291,7 +2469,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@8"
+              "$ref": "#/rules@9"
             },
             "arguments": []
           },
@@ -2315,7 +2493,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               "terminal": {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@6"
+                  "$ref": "#/rules@7"
                 },
                 "arguments": []
               },
@@ -2336,7 +2514,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -2346,7 +2524,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -2357,7 +2535,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@34"
+                        "$ref": "#/rules@35"
                       },
                       "arguments": []
                     }
@@ -2368,7 +2546,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -2378,7 +2556,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -2386,7 +2564,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@9"
+              "$ref": "#/rules@10"
             },
             "arguments": []
           }
@@ -2403,7 +2581,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "AttributeMapping",
       "returnType": {
-        "$ref": "#/interfaces@24"
+        "$ref": "#/interfaces@25"
       },
       "definition": {
         "$type": "Group",
@@ -2423,7 +2601,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "RuleCall",
               "rule": {
-                "$ref": "#/rules@35"
+                "$ref": "#/rules@36"
               },
               "arguments": []
             }
@@ -2442,7 +2620,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@8"
+                  "$ref": "#/rules@9"
                 },
                 "arguments": []
               },
@@ -2452,7 +2630,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                   {
                     "$type": "RuleCall",
                     "rule": {
-                      "$ref": "#/rules@10"
+                      "$ref": "#/rules@11"
                     },
                     "arguments": []
                   },
@@ -2463,7 +2641,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                     "terminal": {
                       "$type": "RuleCall",
                       "rule": {
-                        "$ref": "#/rules@36"
+                        "$ref": "#/rules@37"
                       },
                       "arguments": []
                     }
@@ -2474,7 +2652,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
               {
                 "$type": "RuleCall",
                 "rule": {
-                  "$ref": "#/rules@9"
+                  "$ref": "#/rules@10"
                 },
                 "arguments": []
               }
@@ -2499,7 +2677,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "RuleCall",
                   "rule": {
-                    "$ref": "#/rules@3"
+                    "$ref": "#/rules@4"
                   },
                   "arguments": []
                 }
@@ -2510,7 +2688,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@15"
+              "$ref": "#/rules@16"
             },
             "arguments": [],
             "cardinality": "?"
@@ -2534,12 +2712,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/interfaces@20"
+            "$ref": "#/interfaces@21"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@6"
+              "$ref": "#/rules@7"
             },
             "arguments": []
           },
@@ -2563,12 +2741,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/interfaces@19"
+            "$ref": "#/interfaces@20"
           },
           "terminal": {
             "$type": "RuleCall",
             "rule": {
-              "$ref": "#/rules@6"
+              "$ref": "#/rules@7"
             },
             "arguments": []
           },
@@ -2591,10 +2769,10 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "LogicalEntity",
       "superTypes": [
         {
-          "$ref": "#/interfaces@4"
+          "$ref": "#/interfaces@5"
         },
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -2628,6 +2806,20 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             }
           },
           "isOptional": false
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "identifiers",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "SimpleType",
+              "typeRef": {
+                "$ref": "#/interfaces@2"
+              }
+            }
+          },
+          "isOptional": false
         }
       ]
     },
@@ -2636,10 +2828,10 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "LogicalAttribute",
       "superTypes": [
         {
-          "$ref": "#/interfaces@9"
+          "$ref": "#/interfaces@10"
         },
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -2683,6 +2875,46 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
     },
     {
       "$type": "Interface",
+      "name": "LogicalIdentifier",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@4"
+        },
+        {
+          "$ref": "#/interfaces@11"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "primary",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "boolean"
+          }
+        },
+        {
+          "$type": "TypeAttribute",
+          "name": "attributes",
+          "type": {
+            "$type": "ArrayType",
+            "elementType": {
+              "$type": "ReferenceType",
+              "referenceType": {
+                "$type": "SimpleType",
+                "typeRef": {
+                  "$ref": "#/interfaces@1"
+                }
+              }
+            }
+          },
+          "isOptional": false
+        }
+      ]
+    },
+    {
+      "$type": "Interface",
       "name": "IdentifiedObject",
       "attributes": [
         {
@@ -2702,7 +2934,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "NamedObject",
       "superTypes": [
         {
-          "$ref": "#/interfaces@2"
+          "$ref": "#/interfaces@3"
         }
       ],
       "attributes": [
@@ -2731,7 +2963,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "DataElementContainer",
       "superTypes": [
         {
-          "$ref": "#/interfaces@3"
+          "$ref": "#/interfaces@4"
         }
       ],
       "attributes": []
@@ -2741,7 +2973,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "DataElementContainerLink",
       "superTypes": [
         {
-          "$ref": "#/interfaces@3"
+          "$ref": "#/interfaces@4"
         }
       ],
       "attributes": []
@@ -2751,7 +2983,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "DataElementContainerMapping",
       "superTypes": [
         {
-          "$ref": "#/interfaces@2"
+          "$ref": "#/interfaces@3"
         }
       ],
       "attributes": []
@@ -2761,7 +2993,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "SourceDataElementContainer",
       "superTypes": [
         {
-          "$ref": "#/interfaces@2"
+          "$ref": "#/interfaces@3"
         }
       ],
       "attributes": []
@@ -2771,7 +3003,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "DataElementMapping",
       "superTypes": [
         {
-          "$ref": "#/interfaces@2"
+          "$ref": "#/interfaces@3"
         }
       ],
       "attributes": []
@@ -2781,7 +3013,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "DataElement",
       "superTypes": [
         {
-          "$ref": "#/interfaces@3"
+          "$ref": "#/interfaces@4"
         }
       ],
       "attributes": [
@@ -2808,7 +3040,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/rules@16"
+                "$ref": "#/rules@17"
               }
             }
           },
@@ -2822,10 +3054,10 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "Relationship",
       "superTypes": [
         {
-          "$ref": "#/interfaces@5"
+          "$ref": "#/interfaces@6"
         },
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -2901,7 +3133,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@12"
+                "$ref": "#/interfaces@13"
               }
             }
           },
@@ -2914,7 +3146,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "RelationshipAttribute",
       "superTypes": [
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -2953,7 +3185,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "SystemDiagram",
       "superTypes": [
         {
-          "$ref": "#/interfaces@2"
+          "$ref": "#/interfaces@3"
         }
       ],
       "attributes": [
@@ -2965,7 +3197,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               }
             }
           },
@@ -2979,7 +3211,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@16"
+                "$ref": "#/interfaces@17"
               }
             }
           },
@@ -2992,7 +3224,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "LogicalEntityNode",
       "superTypes": [
         {
-          "$ref": "#/interfaces@2"
+          "$ref": "#/interfaces@3"
         }
       ],
       "attributes": [
@@ -3063,7 +3295,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "SystemDiagramEdge",
       "superTypes": [
         {
-          "$ref": "#/interfaces@2"
+          "$ref": "#/interfaces@3"
         }
       ],
       "attributes": []
@@ -3073,7 +3305,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "RelationshipEdge",
       "superTypes": [
         {
-          "$ref": "#/interfaces@16"
+          "$ref": "#/interfaces@17"
         }
       ],
       "attributes": [
@@ -3085,7 +3317,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@11"
+                "$ref": "#/interfaces@12"
               }
             }
           },
@@ -3099,7 +3331,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               }
             }
           },
@@ -3113,7 +3345,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               }
             }
           },
@@ -3126,7 +3358,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "InheritanceEdge",
       "superTypes": [
         {
-          "$ref": "#/interfaces@16"
+          "$ref": "#/interfaces@17"
         }
       ],
       "attributes": [
@@ -3138,7 +3370,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               }
             }
           },
@@ -3152,7 +3384,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@14"
+                "$ref": "#/interfaces@15"
               }
             }
           },
@@ -3185,10 +3417,10 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "Mapping",
       "superTypes": [
         {
-          "$ref": "#/interfaces@6"
+          "$ref": "#/interfaces@7"
         },
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -3200,7 +3432,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@22"
+                "$ref": "#/interfaces@23"
               }
             }
           },
@@ -3212,7 +3444,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           "type": {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/interfaces@23"
+              "$ref": "#/interfaces@24"
             }
           },
           "isOptional": false
@@ -3224,10 +3456,10 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "SourceObject",
       "superTypes": [
         {
-          "$ref": "#/interfaces@7"
+          "$ref": "#/interfaces@8"
         },
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -3262,7 +3494,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/rules@28"
+                "$ref": "#/rules@29"
               }
             }
           },
@@ -3276,7 +3508,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/rules@29"
+                "$ref": "#/rules@30"
               }
             }
           },
@@ -3289,7 +3521,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "TargetObject",
       "superTypes": [
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -3315,7 +3547,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@24"
+                "$ref": "#/interfaces@25"
               }
             }
           },
@@ -3328,7 +3560,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "AttributeMapping",
       "superTypes": [
         {
-          "$ref": "#/interfaces@10"
+          "$ref": "#/interfaces@11"
         }
       ],
       "attributes": [
@@ -3338,7 +3570,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           "type": {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/rules@35"
+              "$ref": "#/rules@36"
             }
           },
           "isOptional": false
@@ -3351,7 +3583,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/rules@36"
+                "$ref": "#/rules@37"
               }
             }
           },

--- a/extensions/crossmodel-lang/src/language-server/grammar/cross-model.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/cross-model.langium
@@ -6,7 +6,7 @@ import 'system-diagram'
 import 'mapping'
 
 entry CrossModelRoot:
-    (entity=Entity | 
+    (entity=LogicalEntity | 
     relationship=Relationship | 
     systemDiagram=SystemDiagram |
     mapping=Mapping)?;

--- a/extensions/crossmodel-lang/src/language-server/grammar/entity.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/entity.langium
@@ -1,19 +1,19 @@
 import 'terminals'
 import 'common'
 
-interface Entity extends DataElementContainer, WithCustomProperties {
-    superEntities: @Entity[]
+interface LogicalEntity extends DataElementContainer, WithCustomProperties {
+    superEntities: @LogicalEntity[]
     attributes: LogicalAttribute[]
 }
 
-// Entity definition 
-Entity returns Entity:
+// LogicalEntity definition 
+LogicalEntity returns LogicalEntity:
     'entity' ':'
         INDENT
             NamedObjectFragment
             ('inherits' ':'
                 INDENT
-                    (LIST_ITEM superEntities+=[Entity:IDReference])+
+                    (LIST_ITEM superEntities+=[LogicalEntity:IDReference])+
                 DEDENT
             )?
             ('attributes' ':'

--- a/extensions/crossmodel-lang/src/language-server/grammar/entity.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/entity.langium
@@ -4,6 +4,7 @@ import 'common'
 interface LogicalEntity extends DataElementContainer, WithCustomProperties {
     superEntities: @LogicalEntity[]
     attributes: LogicalAttribute[]
+    identifiers: LogicalIdentifier[]
 }
 
 // LogicalEntity definition 
@@ -19,6 +20,11 @@ LogicalEntity returns LogicalEntity:
             ('attributes' ':'
                 INDENT
                     (LIST_ITEM attributes+=LogicalAttribute)+
+                DEDENT
+            )?
+            ('identifiers' ':'
+                INDENT
+                    (LIST_ITEM identifiers+=LogicalIdentifier)+
                 DEDENT
             )?
             CustomPropertiesFragment?
@@ -39,5 +45,21 @@ LogicalAttribute returns LogicalAttribute:
     ('precision' ':' precision=NUMBER)?
     ('scale' ':' scale=NUMBER)?
     (identifier?='identifier' ':' ('TRUE' | 'true'))?
+    CustomPropertiesFragment?
+;
+
+interface LogicalIdentifier extends NamedObject, WithCustomProperties {
+    primary?: boolean;
+    attributes: @LogicalAttribute[]
+}
+
+LogicalIdentifier returns LogicalIdentifier:
+    NamedObjectFragment
+    (primary?='primary' ':' ('TRUE' | 'true'))?
+    ('attributes' ':'
+        INDENT
+            (LIST_ITEM attributes+=[LogicalAttribute:IDReference])+
+        DEDENT
+    )?
     CustomPropertiesFragment?
 ;

--- a/extensions/crossmodel-lang/src/language-server/grammar/mapping.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/mapping.langium
@@ -29,7 +29,7 @@ Mapping returns Mapping:
 ;
 
 interface SourceObject extends SourceDataElementContainer, WithCustomProperties {
-    entity: @Entity;
+    entity: @LogicalEntity;
     join: string;
     dependencies: SourceObjectDependency[]
     conditions: SourceObjectCondition[]
@@ -37,7 +37,7 @@ interface SourceObject extends SourceDataElementContainer, WithCustomProperties 
 
 SourceObject returns SourceObject:
     IdentifiedObjectFragment
-    'entity' ':' entity=[Entity:IDReference] // implies attributes through entity
+    'entity' ':' entity=[LogicalEntity:IDReference] // implies attributes through entity
     'join' ':' join=JoinType
     ('dependencies' ':'
         INDENT
@@ -75,13 +75,13 @@ PrimaryExpression infers BooleanExpression:
 ;
 
 interface TargetObject extends WithCustomProperties {
-    entity: @Entity;
+    entity: @LogicalEntity;
     mappings: AttributeMapping[];
 }
 
 TargetObject returns TargetObject:
     INDENT
-        'entity' ':' entity=[Entity:IDReference] // implies attributes through entity
+        'entity' ':' entity=[LogicalEntity:IDReference] // implies attributes through entity
         ('mappings' ':'
             INDENT 
                 (LIST_ITEM mappings+=AttributeMapping)+     

--- a/extensions/crossmodel-lang/src/language-server/grammar/relationship.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/relationship.langium
@@ -4,10 +4,10 @@ import 'entity'
 
 // Relationship definition
 interface Relationship extends DataElementContainerLink, WithCustomProperties {
-    parent: @Entity
+    parent: @LogicalEntity
     parentRole?: string
     parentCardinality?: string
-    child: @Entity
+    child: @LogicalEntity
     childRole?: string
     childCardinality?: string
     attributes: RelationshipAttribute[]
@@ -19,10 +19,10 @@ Relationship returns Relationship:
     'relationship' ':' 
         INDENT
             NamedObjectFragment
-            'parent' ':' parent=[Entity:IDReference]
+            'parent' ':' parent=[LogicalEntity:IDReference]
             ('parentRole' ':' parentRole=STRING)?
             ('parentCardinality' ':' parentCardinality=Cardinality)?
-            'child' ':' child=[Entity:IDReference]
+            'child' ':' child=[LogicalEntity:IDReference]
             ('childRole' ':' childRole=STRING)?
             ('childCardinality' ':' childCardinality=Cardinality)?
             ('attributes' ':'

--- a/extensions/crossmodel-lang/src/language-server/grammar/system-diagram.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/system-diagram.langium
@@ -5,7 +5,7 @@ import 'relationship'
 
 // Diagram definition
 interface SystemDiagram extends IdentifiedObject {
-    nodes: EntityNode[];
+    nodes: LogicalEntityNode[];
     edges: SystemDiagramEdge[];
 }
 
@@ -15,7 +15,7 @@ SystemDiagram returns SystemDiagram:
         IdentifiedObjectFragment
         ('nodes' ':'
             INDENT 
-                (LIST_ITEM nodes+=EntityNode)+
+                (LIST_ITEM nodes+=LogicalEntityNode)+
             DEDENT
         )?
         ('edges' ':'
@@ -26,24 +26,24 @@ SystemDiagram returns SystemDiagram:
     DEDENT
 ;
 
-interface EntityNode extends IdentifiedObject {
-    entity: @Entity;
+interface LogicalEntityNode extends IdentifiedObject {
+    entity: @LogicalEntity;
     x: number;
     y: number;
     width: number;
     height: number;
 }
 
-EntityNode returns EntityNode:
+LogicalEntityNode returns LogicalEntityNode:
     IdentifiedObjectFragment
-    'entity' ':' entity=[Entity:IDReference]
+    'entity' ':' entity=[LogicalEntity:IDReference]
     'x' ':' x=NUMBER
     'y' ':' y=NUMBER
     'width' ':' width=NUMBER
     'height' ':' height=NUMBER
 ;
 
-interface EntityNodeAttribute extends LogicalAttribute {
+interface LogicalEntityNodeAttribute extends LogicalAttribute {
 }
 
 interface SystemDiagramEdge extends IdentifiedObject {}
@@ -54,24 +54,24 @@ SystemDiagramEdge returns SystemDiagramEdge:
 
 interface RelationshipEdge extends SystemDiagramEdge {
     relationship: @Relationship;
-    sourceNode: @EntityNode;
-    targetNode: @EntityNode;
+    sourceNode: @LogicalEntityNode;
+    targetNode: @LogicalEntityNode;
 }
 
 RelationshipEdge returns RelationshipEdge:
     IdentifiedObjectFragment
     'relationship' ':' relationship=[Relationship:IDReference]
-    'sourceNode' ':' sourceNode=[EntityNode:IDReference]
-    'targetNode' ':' targetNode=[EntityNode:IDReference]
+    'sourceNode' ':' sourceNode=[LogicalEntityNode:IDReference]
+    'targetNode' ':' targetNode=[LogicalEntityNode:IDReference]
 ;
 
 interface InheritanceEdge extends SystemDiagramEdge {
-    baseNode: @EntityNode;
-    superNode: @EntityNode;
+    baseNode: @LogicalEntityNode;
+    superNode: @LogicalEntityNode;
 }
 
 InheritanceEdge returns InheritanceEdge:
     'id' ':' id=ID
-    'baseNode' ':' baseNode=[EntityNode:IDReference]
-    'superNode' ':' superNode=[EntityNode:IDReference]
+    'baseNode' ':' baseNode=[LogicalEntityNode:IDReference]
+    'superNode' ':' superNode=[LogicalEntityNode:IDReference]
 ;

--- a/extensions/crossmodel-lang/src/language-server/util/ast-util.ts
+++ b/extensions/crossmodel-lang/src/language-server/util/ast-util.ts
@@ -116,6 +116,7 @@ export function createLogicalEntity(
       id,
       name,
       attributes: [],
+      identifiers: [],
       customProperties: [],
       superEntities: [],
       ...opts

--- a/extensions/crossmodel-lang/src/language-server/util/ast-util.ts
+++ b/extensions/crossmodel-lang/src/language-server/util/ast-util.ts
@@ -11,10 +11,10 @@ import {
    AttributeMappingSource,
    AttributeMappingTarget,
    CrossModelRoot,
-   Entity,
-   EntityNode,
-   EntityNodeAttribute,
    LogicalAttribute,
+   LogicalEntity,
+   LogicalEntityNode,
+   LogicalEntityNodeAttribute,
    Mapping,
    Relationship,
    RelationshipEdge,
@@ -24,7 +24,7 @@ import {
    TargetObject,
    TargetObjectAttribute,
    isCrossModelRoot,
-   isEntity,
+   isLogicalEntity,
    isMapping,
    isRelationship,
    isSystemDiagram
@@ -51,21 +51,21 @@ export const IMPLICIT_ATTRIBUTES_PROPERTY = '$attributes';
 export const IMPLICIT_OWNER_PROPERTY = '$owner';
 export const IMPLICIT_ID_PROPERTY = '$id';
 
-export function getAttributes(node: EntityNode): EntityNodeAttribute[];
+export function getAttributes(node: LogicalEntityNode): LogicalEntityNodeAttribute[];
 export function getAttributes(node: SourceObject): SourceObjectAttribute[];
 export function getAttributes(node: TargetObject): TargetObjectAttribute[];
 export function getAttributes<T>(node: any): T[] {
    return (node[IMPLICIT_ATTRIBUTES_PROPERTY] as T[]) ?? [];
 }
 
-export function setAttributes(node: EntityNode, attributes: EntityNodeAttribute[]): void;
+export function setAttributes(node: LogicalEntityNode, attributes: LogicalEntityNodeAttribute[]): void;
 export function setAttributes(node: SourceObject, attributes: SourceObjectAttribute[]): void;
 export function setAttributes(node: TargetObject, attributes: TargetObjectAttribute[]): void;
 export function setAttributes(node: object, attributes: LogicalAttribute[]): void {
    (node as any)[IMPLICIT_ATTRIBUTES_PROPERTY] = attributes;
 }
 
-export function getOwner(node: EntityNodeAttribute): EntityNode;
+export function getOwner(node: LogicalEntityNodeAttribute): LogicalEntityNode;
 export function getOwner(node: SourceObjectAttribute): SourceObject;
 export function getOwner(node: TargetObjectAttribute): TargetObject;
 export function getOwner(node?: AstNode): AstNode | undefined;
@@ -73,7 +73,7 @@ export function getOwner<T>(node: any): T | undefined {
    return node?.[IMPLICIT_OWNER_PROPERTY] as T;
 }
 
-export function setOwner(attribute: EntityNodeAttribute, owner: EntityNode): EntityNodeAttribute;
+export function setOwner(attribute: LogicalEntityNodeAttribute, owner: LogicalEntityNode): LogicalEntityNodeAttribute;
 export function setOwner(attribute: SourceObjectAttribute, owner: SourceObject): SourceObjectAttribute;
 export function setOwner(attribute: TargetObjectAttribute, owner: TargetObject): TargetObjectAttribute;
 export function setOwner<T>(attribute: T, owner: object): T {
@@ -104,15 +104,15 @@ export function isImplicitProperty(prop: string, obj: any): boolean {
    );
 }
 
-export function createEntity(
+export function createLogicalEntity(
    container: CrossModelRoot,
    id: string,
    name: string,
-   opts?: Partial<Omit<Entity, '$container' | '$type' | 'id' | 'name'>>
-): Entity {
+   opts?: Partial<Omit<LogicalEntity, '$container' | '$type' | 'id' | 'name'>>
+): LogicalEntity {
    return {
       $container: container,
-      $type: 'Entity',
+      $type: 'LogicalEntity',
       id,
       name,
       attributes: [],
@@ -123,7 +123,7 @@ export function createEntity(
 }
 
 export function createLogicalAttribute(
-   container: Entity,
+   container: LogicalEntity,
    id: string,
    name: string,
    opts?: Partial<Omit<LogicalAttribute, '$container' | '$type' | 'id' | 'name'>>
@@ -143,8 +143,8 @@ export function createRelationship(
    container: CrossModelRoot,
    id: string,
    name: string,
-   parent: Reference<Entity>,
-   child: Reference<Entity>,
+   parent: Reference<LogicalEntity>,
+   child: Reference<LogicalEntity>,
    opts?: Partial<Omit<Relationship, '$container' | '$type' | 'id' | 'name' | 'parent' | 'child'>>
 ): Relationship {
    return {
@@ -178,14 +178,14 @@ export function createSystemDiagram(
 export function createEntityNode(
    container: SystemDiagram,
    id: string,
-   entity: Reference<Entity>,
+   entity: Reference<LogicalEntity>,
    position: Point,
    dimension: Dimension,
-   opts?: Partial<Omit<EntityNode, '$container' | '$type' | 'id' | 'entity'>>
-): EntityNode {
+   opts?: Partial<Omit<LogicalEntityNode, '$container' | '$type' | 'id' | 'entity'>>
+): LogicalEntityNode {
    return {
       $container: container,
-      $type: 'EntityNode',
+      $type: 'LogicalEntityNode',
       id,
       entity,
       ...position,
@@ -198,8 +198,8 @@ export function createRelationshipEdge(
    container: SystemDiagram,
    id: string,
    relationship: Reference<Relationship>,
-   sourceNode: Reference<EntityNode>,
-   targetNode: Reference<EntityNode>,
+   sourceNode: Reference<LogicalEntityNode>,
+   targetNode: Reference<LogicalEntityNode>,
    opts?: Partial<Omit<RelationshipEdge, '$container' | '$type' | 'id' | 'relationship' | 'sourceNode' | 'targetNode'>>
 ): RelationshipEdge {
    return {
@@ -213,7 +213,7 @@ export function createRelationshipEdge(
    };
 }
 
-export function createSourceObject(entity: Entity | AstNodeDescription, container: Mapping, idProvider: IdProvider): SourceObject {
+export function createSourceObject(entity: LogicalEntity | AstNodeDescription, container: Mapping, idProvider: IdProvider): SourceObject {
    const entityId = isAstNodeDescription(entity)
       ? getLocalName(entity)
       : entity.id ?? idProvider.getLocalId(entity) ?? entity.name ?? 'unknown';
@@ -299,7 +299,7 @@ export type DocumentContent = LangiumDocument | AstNode;
 export type TypeGuard<T> = (item: unknown) => item is T;
 
 export function isSemanticRoot(element: unknown): element is SemanticRoot {
-   return isEntity(element) || isMapping(element) || isRelationship(element) || isSystemDiagram(element);
+   return isLogicalEntity(element) || isMapping(element) || isRelationship(element) || isSystemDiagram(element);
 }
 
 export function findSemanticRoot(input: DocumentContent): SemanticRoot | undefined;
@@ -325,8 +325,8 @@ export function getSemanticRootFromAstRoot<T extends SemanticRoot>(
    return undefined;
 }
 
-export function findEntity(input: DocumentContent): Entity | undefined {
-   return findSemanticRoot(input, isEntity);
+export function findEntity(input: DocumentContent): LogicalEntity | undefined {
+   return findSemanticRoot(input, isLogicalEntity);
 }
 
 export function findRelationship(input: DocumentContent): Relationship | undefined {

--- a/extensions/crossmodel-lang/syntaxes/cross-model.tmLanguage.json
+++ b/extensions/crossmodel-lang/syntaxes/cross-model.tmLanguage.json
@@ -10,7 +10,7 @@
     },
     {
       "name": "keyword.control.cross-model",
-      "match": "\\b(TRUE|apply|attribute|attributes|baseNode|child|childCardinality|childRole|conditions|cross-join|customProperties|datatype|dependencies|description|diagram|edges|entity|expression|from|height|id|identifier|inherits|inner-join|join|left-join|length|mapping|mappings|multiple|name|nodes|one|parent|parentCardinality|parentRole|precision|relationship|scale|sourceNode|sources|superNode|systemDiagram|target|targetNode|true|value|width|x|y|zero)\\b"
+      "match": "\\b(TRUE|apply|attribute|attributes|baseNode|child|childCardinality|childRole|conditions|cross-join|customProperties|datatype|dependencies|description|diagram|edges|entity|expression|from|height|id|identifier|identifiers|inherits|inner-join|join|left-join|length|mapping|mappings|multiple|name|nodes|one|parent|parentCardinality|parentRole|precision|primary|relationship|scale|sourceNode|sources|superNode|systemDiagram|target|targetNode|true|value|width|x|y|zero)\\b"
     },
     {
       "name": "string.quoted.double.cross-model",

--- a/extensions/crossmodel-lang/test/language-server/cross-model-filename.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-filename.test.ts
@@ -4,17 +4,17 @@
 
 import { ModelFileExtensions } from '@crossbreeze/protocol';
 import { entity1 } from './test-utils/test-documents/entity/entity1.js';
-import { createCrossModelTestServices, parseEntity, testUri } from './test-utils/utils.js';
+import { createCrossModelTestServices, parseLogicalEntity, testUri } from './test-utils/utils.js';
 
 const services = createCrossModelTestServices();
 
 describe('CrossModel Filename Validation', () => {
    test('Mismatching id and filename does not yield error', async () => {
-      const entity = await parseEntity({
+      const entity = await parseLogicalEntity({
          services,
          text: entity1,
          validation: true,
-         documentUri: testUri('Customer2' + ModelFileExtensions.Entity)
+         documentUri: testUri('Customer2' + ModelFileExtensions.LogicalEntity)
       });
       expect(entity.id).toBe('Customer');
       expect(entity.$document.diagnostics).toHaveLength(1);

--- a/extensions/crossmodel-lang/test/language-server/cross-model-lang-entity.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-lang-entity.test.ts
@@ -5,14 +5,14 @@
 import { describe, expect, test } from '@jest/globals';
 
 import { entity1, entity2, entity3, entity4 } from './test-utils/test-documents/entity/index.js';
-import { createCrossModelTestServices, parseEntity } from './test-utils/utils.js';
+import { createCrossModelTestServices, parseLogicalEntity } from './test-utils/utils.js';
 
 const services = createCrossModelTestServices();
 
 describe('CrossModel language Entity', () => {
    describe('Without attributes', () => {
       test('Simple file for entity', async () => {
-         const entity = await parseEntity({ services, text: entity1 });
+         const entity = await parseLogicalEntity({ services, text: entity1 });
          expect(entity.id).toBe('Customer');
          expect(entity.name).toBe('Customer');
          expect(entity.description).toBe('A customer with whom a transaction has been made.');
@@ -21,7 +21,7 @@ describe('CrossModel language Entity', () => {
 
    describe('With attributes', () => {
       test('entity with attributes', async () => {
-         const entity = await parseEntity({ services, text: entity2 });
+         const entity = await parseLogicalEntity({ services, text: entity2 });
          expect(entity.attributes.length).toBe(6);
          expect(entity.attributes[0].id).toBe('Id');
          expect(entity.attributes[0].name).toBe('Id');
@@ -29,7 +29,7 @@ describe('CrossModel language Entity', () => {
       });
 
       test('entity with attributes coming before the description and name', async () => {
-         const entity = await parseEntity({ services, text: entity4 }, { parserErrors: 3 });
+         const entity = await parseLogicalEntity({ services, text: entity4 }, { parserErrors: 3 });
          expect(entity.id).toBe('Customer');
          expect(entity.name).toBeUndefined();
          expect(entity.description).toBeUndefined();
@@ -41,7 +41,7 @@ describe('CrossModel language Entity', () => {
       });
 
       test('entity with indentation error', async () => {
-         await parseEntity({ services, text: entity3 }, { parserErrors: 1 });
+         await parseLogicalEntity({ services, text: entity3 }, { parserErrors: 1 });
       });
    });
 });

--- a/extensions/crossmodel-lang/test/language-server/cross-model-naming.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-naming.test.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 import { describe, expect, test } from '@jest/globals';
-import { EntityNode } from '../../src/language-server/generated/ast.js';
+import { LogicalEntityNode } from '../../src/language-server/generated/ast.js';
 import { createCrossModelTestServices, parseSystemDiagram } from './test-utils/utils.js';
 
 const services = createCrossModelTestServices();
@@ -65,22 +65,22 @@ describe('NameUtil', () => {
    describe('findAvailableNodeName', () => {
       test('should return given name if unique', async () => {
          const diagram = await parseSystemDiagram({ services, text: ex1 });
-         expect(services.references.IdProvider.findNextId(EntityNode, 'nodeA', diagram)).toBe('nodeA');
+         expect(services.references.IdProvider.findNextId(LogicalEntityNode, 'nodeA', diagram)).toBe('nodeA');
       });
 
       test('should return unique name if given is taken', async () => {
          const diagram = await parseSystemDiagram({ services, text: ex2 });
-         expect(services.references.IdProvider.findNextId(EntityNode, 'nodeA', diagram)).toBe('nodeA1');
+         expect(services.references.IdProvider.findNextId(LogicalEntityNode, 'nodeA', diagram)).toBe('nodeA1');
       });
 
       test('should properly count up if name is taken', async () => {
          const diagram = await parseSystemDiagram({ services, text: ex3 });
-         expect(services.references.IdProvider.findNextId(EntityNode, 'nodeA', diagram)).toBe('nodeA2');
+         expect(services.references.IdProvider.findNextId(LogicalEntityNode, 'nodeA', diagram)).toBe('nodeA2');
       });
 
       test('should find lowest count if multiple are taken', async () => {
          const diagram = await parseSystemDiagram({ services, text: ex4 });
-         expect(services.references.IdProvider.findNextId(EntityNode, 'nodeA', diagram)).toBe('nodeA3');
+         expect(services.references.IdProvider.findNextId(LogicalEntityNode, 'nodeA', diagram)).toBe('nodeA3');
       });
    });
 });

--- a/extensions/crossmodel-lang/test/language-server/serializer/cross-model-serializer.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/serializer/cross-model-serializer.test.ts
@@ -7,11 +7,11 @@ import { Reference, URI } from 'langium';
 
 import _ from 'lodash';
 import { CrossModelSerializer } from '../../../src/language-server/cross-model-serializer.js';
-import { CrossModelRoot, Entity, Relationship } from '../../../src/language-server/generated/ast.js';
+import { CrossModelRoot, LogicalEntity, Relationship } from '../../../src/language-server/generated/ast.js';
 import {
-   createEntity,
    createEntityNode,
    createLogicalAttribute,
+   createLogicalEntity,
    createRelationship,
    createRelationshipEdge,
    createSystemDiagram
@@ -20,7 +20,7 @@ import { customer } from '../test-utils/test-documents/entity/customer.js';
 import { sub_customer } from '../test-utils/test-documents/entity/sub_customer.js';
 import { sub_customer_cycle } from '../test-utils/test-documents/entity/sub_customer_cycle.js';
 import { sub_customer_multi } from '../test-utils/test-documents/entity/sub_customer_multi.js';
-import { createCrossModelTestServices, parseDocuments, parseEntity, testUri } from '../test-utils/utils.js';
+import { createCrossModelTestServices, parseDocuments, parseLogicalEntity, testUri } from '../test-utils/utils.js';
 
 const services = createCrossModelTestServices();
 
@@ -38,7 +38,7 @@ describe('CrossModelLexer', () => {
 
       beforeAll(() => {
          crossModelRoot = { $type: 'CrossModelRoot' };
-         crossModelRoot.entity = createEntity(crossModelRoot, 'testId', 'test Name', {
+         crossModelRoot.entity = createLogicalEntity(crossModelRoot, 'testId', 'test Name', {
             description: 'Test description'
          });
 
@@ -50,7 +50,7 @@ describe('CrossModelLexer', () => {
          ];
 
          crossModelRootWithAttributesDifPlace = { $type: 'CrossModelRoot' };
-         crossModelRootWithAttributesDifPlace.entity = createEntity(crossModelRoot, 'testId', 'test Name', {
+         crossModelRootWithAttributesDifPlace.entity = createLogicalEntity(crossModelRoot, 'testId', 'test Name', {
             description: 'Test description'
          });
          crossModelRootWithAttributesDifPlace.entity.attributes = [
@@ -83,16 +83,16 @@ describe('CrossModelLexer', () => {
             $type: 'CrossModelRoot'
          };
 
-         const ref1: Reference<Entity> = {
+         const ref1: Reference<LogicalEntity> = {
             $refText: 'Ref1',
-            ref: createEntity(crossModelRoot, 'Ref1', 'test Name', {
+            ref: createLogicalEntity(crossModelRoot, 'Ref1', 'test Name', {
                description: 'Test description'
             })
          };
 
-         const ref2: Reference<Entity> = {
+         const ref2: Reference<LogicalEntity> = {
             $refText: 'Ref2',
-            ref: createEntity(crossModelRoot, 'Ref2', 'test Name', {
+            ref: createLogicalEntity(crossModelRoot, 'Ref2', 'test Name', {
                description: 'Test description'
             })
          };
@@ -116,16 +116,16 @@ describe('CrossModelLexer', () => {
             $type: 'CrossModelRoot'
          };
 
-         const ref1: Reference<Entity> = {
+         const ref1: Reference<LogicalEntity> = {
             $refText: 'Ref1',
-            ref: createEntity(crossModelRoot, 'Ref1', 'test Name', {
+            ref: createLogicalEntity(crossModelRoot, 'Ref1', 'test Name', {
                description: 'Test description'
             })
          };
 
-         const ref2: Reference<Entity> = {
+         const ref2: Reference<LogicalEntity> = {
             $refText: 'Ref2',
-            ref: createEntity(crossModelRoot, 'Ref2', 'test Name', {
+            ref: createLogicalEntity(crossModelRoot, 'Ref2', 'test Name', {
                description: 'Test description'
             })
          };
@@ -163,13 +163,13 @@ describe('CrossModelLexer', () => {
       });
 
       test('Single inheritance', async () => {
-         const subCustomer = await parseEntity({ services, text: sub_customer });
+         const subCustomer = await parseLogicalEntity({ services, text: sub_customer });
          expect(subCustomer.superEntities).toHaveLength(1);
          expect(subCustomer.superEntities[0].$refText).toBe('Customer');
       });
 
       test('Multiple inheritance', async () => {
-         const subCustomer = await parseEntity({ services, text: sub_customer_multi });
+         const subCustomer = await parseLogicalEntity({ services, text: sub_customer_multi });
          expect(subCustomer.superEntities).toHaveLength(2);
          expect(subCustomer.superEntities[0].$refText).toBe('Customer');
          expect(subCustomer.superEntities[1].$refText).toBe('SubCustomer');
@@ -177,7 +177,7 @@ describe('CrossModelLexer', () => {
 
       test('Inheritance Cycle', async () => {
          services.shared.workspace.LangiumDocuments.deleteDocument(URI.parse(customerDocumentUri));
-         const newCustomer = await parseEntity({ services, text: sub_customer_cycle, documentUri: 'customer', validation: true });
+         const newCustomer = await parseLogicalEntity({ services, text: sub_customer_cycle, documentUri: 'customer', validation: true });
          expect(newCustomer.$document.diagnostics).toBeDefined();
          expect(newCustomer.$document.diagnostics).toEqual(
             expect.arrayContaining([

--- a/extensions/crossmodel-lang/test/language-server/test-utils/utils.ts
+++ b/extensions/crossmodel-lang/test/language-server/test-utils/utils.ts
@@ -10,11 +10,11 @@ import { PackageJson } from 'type-fest';
 import { CrossModelServices, createCrossModelServices } from '../../../src/language-server/cross-model-module.js';
 import {
    CrossModelRoot,
-   Entity,
+   LogicalEntity,
    Mapping,
    Relationship,
    SystemDiagram,
-   isEntity,
+   isLogicalEntity,
    isMapping,
    isRelationship,
    isSystemDiagram
@@ -87,8 +87,8 @@ export async function parseSemanticRoot<T extends SemanticRoot>(
    return semanticRoot as WithDocument<T>;
 }
 
-export async function parseEntity(input: DocumentInput, assert: ParseAssert = {}): Promise<WithDocument<Entity>> {
-   return parseSemanticRoot(input, assert, isEntity);
+export async function parseLogicalEntity(input: DocumentInput, assert: ParseAssert = {}): Promise<WithDocument<LogicalEntity>> {
+   return parseSemanticRoot(input, assert, isLogicalEntity);
 }
 
 export async function parseRelationship(input: DocumentInput, assert: ParseAssert = {}): Promise<WithDocument<Relationship>> {

--- a/packages/composite-editor/src/browser/composite-editor.ts
+++ b/packages/composite-editor/src/browser/composite-editor.ts
@@ -208,7 +208,7 @@ export class CompositeEditor extends BaseWidget implements SaveableSource, Navig
 
    protected async createPrimaryWidget(options: CompositeWidgetOptions): Promise<Widget> {
       switch (this.fileType) {
-         case 'Entity':
+         case 'LogicalEntity':
             return this.createFormWidget(options);
          case 'Relationship':
             return this.createFormWidget(options);

--- a/packages/core/src/browser/cm-file-label-provider.ts
+++ b/packages/core/src/browser/cm-file-label-provider.ts
@@ -34,8 +34,8 @@ export class CrossModelLabelProvider implements LabelProviderContribution, TreeD
       if (this.isSystemDirectory(node)) {
          return ModelStructure.System.ICON_CLASS + ' default-folder-icon';
       }
-      if (this.isSystemDirectory(node.parent) && node.fileStat.name === ModelStructure.Entity.FOLDER) {
-         return ModelStructure.Entity.ICON_CLASS + ' default-folder-icon';
+      if (this.isSystemDirectory(node.parent) && node.fileStat.name === ModelStructure.LogicalEntity.FOLDER) {
+         return ModelStructure.LogicalEntity.ICON_CLASS + ' default-folder-icon';
       }
       if (this.isSystemDirectory(node.parent) && node.fileStat.name === ModelStructure.Relationship.FOLDER) {
          return ModelStructure.Relationship.ICON_CLASS + ' default-folder-icon';

--- a/packages/core/src/browser/import-export-contribution.ts
+++ b/packages/core/src/browser/import-export-contribution.ts
@@ -355,8 +355,8 @@ export class ImportExportContribution implements CommandContribution, MenuContri
    }
 
    protected subFolder(modelType: ModelFileType): string {
-      if (modelType === 'Entity') {
-         return ModelStructure.Entity.FOLDER + '/';
+      if (modelType === 'LogicalEntity') {
+         return ModelStructure.LogicalEntity.FOLDER + '/';
       }
       if (modelType === 'Relationship') {
          return ModelStructure.Relationship.FOLDER + '/';

--- a/packages/core/src/browser/new-element-contribution.ts
+++ b/packages/core/src/browser/new-element-contribution.ts
@@ -62,10 +62,10 @@ const NEW_ELEMENT_TEMPLATES: NewElementTemplate[] = [
    {
       id: 'crossbreeze.new.entity',
       label: 'Entity',
-      memberType: 'Entity',
-      toUri: joinWithExt(ModelFileExtensions.Entity, join),
+      memberType: 'LogicalEntity',
+      toUri: joinWithExt(ModelFileExtensions.LogicalEntity, join),
       category: TEMPLATE_CATEGORY,
-      iconClass: ModelStructure.Entity.ICON_CLASS,
+      iconClass: ModelStructure.LogicalEntity.ICON_CLASS,
       content: ({ name }) =>
          INITIAL_ENTITY_CONTENT.replace(/\$\{name\}/gi, quote(toPascal(name))).replace(/\$\{id\}/gi, toId(toPascal(name)))
    },

--- a/packages/protocol/src/model-service/protocol.ts
+++ b/packages/protocol/src/model-service/protocol.ts
@@ -43,7 +43,7 @@ export interface CrossModelDocument<T = CrossModelRoot, D = ModelDiagnostic> {
 
 export interface CrossModelRoot extends CrossModelElement {
    readonly $type: 'CrossModelRoot';
-   entity?: Entity;
+   entity?: LogicalEntity;
    relationship?: Relationship;
    mapping?: Mapping;
    systemDiagram?: SystemDiagram;
@@ -56,9 +56,9 @@ export function isCrossModelRoot(model?: any): model is CrossModelRoot {
    return !!model && model.$type === 'CrossModelRoot';
 }
 
-export const EntityType = 'Entity';
-export interface Entity extends CrossModelElement, Identifiable, WithCustomProperties {
-   readonly $type: typeof EntityType;
+export const LogicalEntityType = 'LogicalEntity';
+export interface LogicalEntity extends CrossModelElement, Identifiable, WithCustomProperties {
+   readonly $type: typeof LogicalEntityType;
    attributes: Array<LogicalAttribute>;
    description?: string;
    name?: string;
@@ -81,9 +81,9 @@ export interface Relationship extends CrossModelElement, Identifiable, WithCusto
    readonly $type: typeof RelationshipType;
    name?: string;
    attributes: Array<RelationshipAttribute>;
-   parent?: Reference<Entity>;
+   parent?: Reference<LogicalEntity>;
    parentCardinality?: string;
-   child?: Reference<Entity>;
+   child?: Reference<LogicalEntity>;
    childCardinality?: string;
    description?: string;
 }
@@ -106,7 +106,7 @@ export const SourceObjectType = 'SourceObject';
 export type SourceObjectJoinType = 'from' | 'inner-join' | 'cross-join' | 'left-join' | 'apply';
 export interface SourceObject extends CrossModelElement, Identifiable, WithCustomProperties {
    readonly $type: typeof SourceObjectType;
-   entity?: Reference<Entity>;
+   entity?: Reference<LogicalEntity>;
    join?: SourceObjectJoinType;
    dependencies: Array<SourceObjectDependency>;
    conditions: Array<SourceObjectCondition>;
@@ -157,7 +157,7 @@ export interface SourceObjectAttributeReference extends CrossModelElement {
 export const TargetObjectType = 'TargetObject';
 export interface TargetObject extends CrossModelElement, WithCustomProperties {
    readonly $type: typeof TargetObjectType;
-   entity?: Reference<Entity>;
+   entity?: Reference<LogicalEntity>;
    mappings: Array<AttributeMapping>;
 }
 
@@ -230,7 +230,7 @@ export interface EntityNode extends CrossModelElement, Identifiable, WithCustomP
    readonly $type: typeof EntityNodeType;
    customProperties: Array<CustomProperty>;
    description?: string;
-   entity: Reference<Entity>;
+   entity: Reference<LogicalEntity>;
    height: number;
    name?: string;
    width: number;
@@ -414,8 +414,8 @@ export const RequestSystemInfo = new rpc.RequestType1<SystemInfoArgs, SystemInfo
 export const OnSystemsUpdated = new rpc.NotificationType1<SystemUpdatedEvent>('server/onSystemsUpdated');
 
 export const ModelMemberPermissions = {
-   logical: ['Entity', 'Mapping', 'Relationship', 'SystemDiagram'],
-   physical: []
+   logical: ['LogicalEntity', 'Mapping', 'Relationship', 'SystemDiagram'],
+   relational: []
 } as const satisfies Record<string, readonly RootObjectTypeName[]>;
 
 export function isMemberPermittedInModel(packageType: string, memberType: string): boolean {

--- a/packages/protocol/src/model.ts
+++ b/packages/protocol/src/model.ts
@@ -4,7 +4,7 @@
 
 const ModelFileTypeValues = {
    Generic: 'Generic',
-   Entity: 'Entity',
+   LogicalEntity: 'LogicalEntity',
    Relationship: 'Relationship',
    Mapping: 'Mapping',
    SystemDiagram: 'SystemDiagram'
@@ -14,8 +14,8 @@ export const ModelFileType = {
    ...ModelFileTypeValues,
    getIconClass: (type: ModelFileType) => {
       switch (type) {
-         case 'Entity':
-            return ModelStructure.Entity.ICON_CLASS;
+         case 'LogicalEntity':
+            return ModelStructure.LogicalEntity.ICON_CLASS;
          case 'Relationship':
             return ModelStructure.Relationship.ICON_CLASS;
          case 'SystemDiagram':
@@ -28,8 +28,8 @@ export const ModelFileType = {
    },
    getFileExtension(type: ModelFileType): string | undefined {
       switch (type) {
-         case 'Entity':
-            return ModelFileExtensions.Entity;
+         case 'LogicalEntity':
+            return ModelFileExtensions.LogicalEntity;
          case 'Generic':
             return ModelFileExtensions.Generic;
          case 'Mapping':
@@ -45,7 +45,7 @@ export type ModelFileType = (typeof ModelFileTypeValues)[keyof typeof ModelFileT
 
 export const ModelFileExtensions = {
    Generic: '.cm',
-   Entity: '.entity.cm',
+   LogicalEntity: '.entity.cm',
    Relationship: '.relationship.cm',
    Mapping: '.mapping.cm',
    SystemDiagram: '.system-diagram.cm',
@@ -57,7 +57,7 @@ export const ModelFileExtensions = {
    },
 
    isEntityFile(uri: string): boolean {
-      return uri.endsWith(this.Entity);
+      return uri.endsWith(this.LogicalEntity);
    },
 
    isRelationshipFile(uri: string): boolean {
@@ -74,8 +74,8 @@ export const ModelFileExtensions = {
 
    getName(uri: string): string {
       // since we have file extensions with two '.', we cannot use the default implementation that only works for one '.'
-      if (uri.endsWith(this.Entity)) {
-         return uri.substring(0, uri.length - this.Entity.length);
+      if (uri.endsWith(this.LogicalEntity)) {
+         return uri.substring(0, uri.length - this.LogicalEntity.length);
       }
       if (uri.endsWith(this.Relationship)) {
          return uri.substring(0, uri.length - this.Relationship.length);
@@ -105,7 +105,7 @@ export const ModelFileExtensions = {
          return 'Relationship';
       }
       if (this.isEntityFile(uri)) {
-         return 'Entity';
+         return 'LogicalEntity';
       }
       if (this.isModelFile(uri)) {
          return 'Generic';
@@ -124,8 +124,8 @@ export const ModelFileExtensions = {
          return undefined;
       }
       switch (fileType) {
-         case 'Entity':
-            return ModelStructure.Entity.ICON_CLASS;
+         case 'LogicalEntity':
+            return ModelStructure.LogicalEntity.ICON_CLASS;
          case 'Relationship':
             return ModelStructure.Relationship.ICON_CLASS;
          case 'SystemDiagram':
@@ -139,7 +139,7 @@ export const ModelFileExtensions = {
 
    detectFileType(content: string): ModelFileType | undefined {
       if (content.startsWith('entity')) {
-         return 'Entity';
+         return 'LogicalEntity';
       }
       if (content.startsWith('relationship')) {
          return 'Relationship';
@@ -164,7 +164,7 @@ export const ModelStructure = {
       ICON_CLASS: 'codicon codicon-globe',
       ICON: 'globe'
    },
-   Entity: {
+   LogicalEntity: {
       FOLDER: 'entities',
       ICON_CLASS: 'codicon codicon-git-commit',
       ICON: 'git-commit'

--- a/packages/react-model-ui/src/ModelContext.tsx
+++ b/packages/react-model-ui/src/ModelContext.tsx
@@ -4,7 +4,7 @@
 import {
    CrossModelRoot,
    CrossReferenceContext,
-   Entity,
+   LogicalEntity,
    Mapping,
    ModelDiagnostic,
    ReferenceableElement,
@@ -72,7 +72,7 @@ export function useReadonly(): boolean {
    return ModelDiagnostic.hasErrors(useDiagnostics());
 }
 
-export function useEntity(): Entity {
+export function useEntity(): LogicalEntity {
    return useModel().entity!;
 }
 

--- a/packages/react-model-ui/src/views/common/RelationshipAttributesDataGrid.tsx
+++ b/packages/react-model-ui/src/views/common/RelationshipAttributesDataGrid.tsx
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
-import { CrossReferenceContext, EntityType, RelationshipAttribute, RelationshipAttributeType } from '@crossbreeze/protocol';
+import { CrossReferenceContext, LogicalEntityType, RelationshipAttribute, RelationshipAttributeType } from '@crossbreeze/protocol';
 import { GridColDef, GridRenderEditCellParams, useGridApiContext } from '@mui/x-data-grid';
 import * as React from 'react';
 import { useModelDispatch, useModelQueryApi, useReadonly, useRelationship } from '../../ModelContext';
@@ -48,7 +48,7 @@ export function EditAttributePropertyComponent({
          label=''
          optionLoader={referenceableElements}
          onChange={(_evt, newReference) => handleValueChange(newReference.label)}
-         value={{ uri: '', label: value ?? '', type: EntityType }}
+         value={{ uri: '', label: value ?? '', type: LogicalEntityType }}
          clearOnBlur={true}
          selectOnFocus={true}
          disabled={readonly}

--- a/packages/react-model-ui/src/views/form/EntityForm.tsx
+++ b/packages/react-model-ui/src/views/form/EntityForm.tsx
@@ -18,7 +18,7 @@ export function EntityForm(): React.ReactElement {
    const readonly = useReadonly();
 
    return (
-      <Form id={entity.id} name={entity.name ?? ModelFileType.Entity} iconClass={ModelStructure.Entity.ICON_CLASS}>
+      <Form id={entity.id} name={entity.name ?? ModelFileType.LogicalEntity} iconClass={ModelStructure.LogicalEntity.ICON_CLASS}>
          <FormSection label='General'>
             <TextField
                fullWidth={true}

--- a/packages/react-model-ui/src/views/form/RelationshipForm.tsx
+++ b/packages/react-model-ui/src/views/form/RelationshipForm.tsx
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 
-import { EntityType, ModelFileType, ModelStructure, ReferenceableElement } from '@crossbreeze/protocol';
+import { LogicalEntityType, ModelFileType, ModelStructure, ReferenceableElement } from '@crossbreeze/protocol';
 import { Autocomplete, TextField } from '@mui/material';
 import * as React from 'react';
 import { useModelDispatch, useModelQueryApi, useReadonly, useRelationship } from '../../ModelContext';
@@ -50,7 +50,7 @@ export function RelationshipForm(): React.ReactElement {
                optionLoader={referenceableElements}
                getOptionLabel={referenceLabelProvider}
                onChange={(_evt, newReference) => dispatch({ type: 'relationship:change-parent', parent: newReference.label })}
-               value={{ uri: '', label: relationship.parent ?? '', type: EntityType }}
+               value={{ uri: '', label: relationship.parent ?? '', type: LogicalEntityType }}
                disabled={readonly}
                selectOnFocus={true}
             />
@@ -70,7 +70,7 @@ export function RelationshipForm(): React.ReactElement {
                optionLoader={referenceableElements}
                getOptionLabel={referenceLabelProvider}
                onChange={(_evt, newReference) => dispatch({ type: 'relationship:change-child', child: newReference.label })}
-               value={{ uri: '', label: relationship.child ?? '', type: EntityType }}
+               value={{ uri: '', label: relationship.child ?? '', type: LogicalEntityType }}
                clearOnBlur={true}
                disabled={readonly}
                selectOnFocus={true}


### PR DESCRIPTION
- Refactored Entity to LogicalEntity in grammar, protocol, GLSP and front-end where necessary).
- Added identifiers property to LogicalEntity, where multiple identifiers can be modelled including validation.

_Note: there is still an identifier property on LogicalAttribute, which we need to remove from the grammar and refactor (in the future) to be a calculated property based on the identifiers property on LogicalEntity._