### PR TITLE
Object creation with dialogues

### DIFF
--- a/e2e-tests/src/tests/form/add-edit-delete-relationship.spec.ts
+++ b/e2e-tests/src/tests/form/add-edit-delete-relationship.spec.ts
@@ -46,8 +46,9 @@ test.describe('Add/Edit/Delete relationship from explorer', () => {
       const editor = await app.openCompositeEditor(NEW_RELATIONSHIP_PATH, 'Code Editor');
       expect(await editor.textContentOfLineByLineNumber(1)).toBe('relationship:');
       expect(await editor.textContentOfLineByLineNumber(2)).toMatch('id: NewRelationship');
-      expect(await editor.textContentOfLineByLineNumber(3)).toMatch('parent:');
-      expect(await editor.textContentOfLineByLineNumber(4)).toMatch('child:');
+      expect(await editor.textContentOfLineByLineNumber(3)).toMatch('name: "NewRelationship"');
+      expect(await editor.textContentOfLineByLineNumber(4)).toMatch('parent: Address');
+      expect(await editor.textContentOfLineByLineNumber(5)).toMatch('child: Customer');
       await editor.close();
    });
 

--- a/e2e-tests/src/tests/model/add-delete-model.spec.ts
+++ b/e2e-tests/src/tests/model/add-delete-model.spec.ts
@@ -20,9 +20,9 @@ async function confirmCreationDialog(app: CMApp, entityName: string, modelType: 
 
 test.describe.serial('Add/Edit/Delete model from explorer', () => {
    let app: CMApp;
-   const NEW_MODEL_PATH = 'testFolder/NewModel';
-   const NEW_MODEL_PACKAGE_PATH = 'testFolder/NewModel/package.json';
-   const NEW_MODEL2_PATH = 'testFolder/NewModel2';
+   const NEW_MODEL_PATH = 'testFolder/NewDataModel';
+   const NEW_MODEL_PACKAGE_PATH = 'testFolder/NewDataModel/package.json';
+   const NEW_MODEL2_PATH = 'testFolder/NewDataModel2';
    test.beforeAll(async ({ browser, playwright }) => {
       app = await CMApp.load({ browser, playwright });
    });
@@ -40,11 +40,11 @@ test.describe.serial('Add/Edit/Delete model from explorer', () => {
       if (!tabBarToolbarNewModel) {
          return;
       }
-      const name = 'NewModel';
-      const modeltype = 'logical';
+      const name = 'new-data-model';
+      const modelType = 'logical';
       const version = '0.0.1';
       await tabBarToolbarNewModel.trigger();
-      await confirmCreationDialog(app, 'NewModel', 'logical', '0.0.1');
+      await confirmCreationDialog(app, name, modelType, version);
 
       // Verify that the model was created as expected
       await explorer.activate();
@@ -54,7 +54,7 @@ test.describe.serial('Add/Edit/Delete model from explorer', () => {
       const editor = await app.openEditor(NEW_MODEL_PACKAGE_PATH, TheiaTextEditor);
       expect((await editor.textContentOfLineByLineNumber(2))?.trim()).toBe(`"name": "${name}",`);
       expect((await editor.textContentOfLineByLineNumber(3))?.trim()).toBe(`"version": "${version}",`);
-      expect((await editor.textContentOfLineByLineNumber(4))?.trim()).toBe(`"type": "${modeltype}",`);
+      expect((await editor.textContentOfLineByLineNumber(4))?.trim()).toBe(`"type": "${modelType}",`);
       expect((await editor.textContentOfLineByLineNumber(5))?.trim()).toBe('"dependencies": {}');
       await editor.saveAndClose();
       await explorer.activate();
@@ -85,7 +85,7 @@ test.describe.serial('Add/Edit/Delete model from explorer', () => {
       const menuItem = await contextMenu.menuItemByNamePath('New Element', 'Data Model...');
       expect(menuItem).toBeDefined();
       await menuItem?.click();
-      await confirmCreationDialog(app, 'NewModel2', 'relational', '0.0.2');
+      await confirmCreationDialog(app, 'new-data-model-2', 'relational', '0.0.2');
       await explorer.activate();
 
       // Verify that the model was created as expected

--- a/extensions/crossmodel-lang/src/language-server/cross-model-package-manager.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-package-manager.ts
@@ -166,7 +166,7 @@ export class CrossModelPackageManager {
       // find closest package info based on the given URI
       // we prefer longer path names as we are deeper in the nested hierarchy
       const packageInfos = [...this.uriToPackage.values()]
-         .filter(info => Utils.isChildOf(info.directory, uri))
+         .filter(info => Utils.isEqualOrParent(info.directory, uri))
          .sort((left, right) => right.directory.fsPath.length - left.directory.fsPath.length);
 
       return packageInfos[0];

--- a/extensions/crossmodel-lang/test/language-server/cross-model-completion-provider.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-completion-provider.test.ts
@@ -12,7 +12,7 @@ import { createCrossModelTestServices, MockFileSystem, parseProject, testUri } f
 const services = createCrossModelTestServices(MockFileSystem);
 const assertCompletion = expectCompletion(services);
 
-describe('CrossModelCompletionProvider', () => {
+describe.only('CrossModelCompletionProvider', () => {
    const text = expandToString`
     relationship:
        id: Address_Customer
@@ -46,6 +46,16 @@ describe('CrossModelCompletionProvider', () => {
          index: 0,
          expectedItems: ['Address', 'Order'],
          disposeAfterCheck: true
+      });
+   });
+
+   test('Completion for entity references in project A at scope of project A root directory', async () => {
+      await assertCompletion({
+         text,
+         parseOptions: { documentUri: testUri('projectA') },
+         index: 0,
+         expectedItems: ['Address', 'Order'],
+         disposeAfterCheck: false
       });
    });
 

--- a/packages/core/src/browser/grid-dialog.ts
+++ b/packages/core/src/browser/grid-dialog.ts
@@ -2,8 +2,8 @@
  * Copyright (c) 2025 CrossBreeze.
  ********************************************************************************/
 
-import { inject } from '@theia/core/shared/inversify';
 import { LabelProvider } from '@theia/core/lib/browser';
+import { inject } from '@theia/core/shared/inversify';
 import { WorkspaceInputDialog, WorkspaceInputDialogProps } from '@theia/workspace/lib/browser/workspace-input-dialog';
 
 const GridInputDialogProps = Symbol('GridInputDialogProps');
@@ -49,7 +49,10 @@ export class GridInputDialog extends WorkspaceInputDialog {
          if (!inputFieldSet && !inputProps.options) {
             inputFieldSet = true;
             this.inputField.id = computedId;
+            this.inputField.placeholder = inputProps.placeholder || this.inputField.placeholder;
+            this.inputField.value = inputProps.value || this. inputField.value;
             this.grid.appendChild(this.inputField);
+            this.inputField.select();
          } else {
             const input = createInput({ ...inputProps, id: computedId });
             this.grid.appendChild(input);

--- a/packages/protocol/src/util.ts
+++ b/packages/protocol/src/util.ts
@@ -70,3 +70,12 @@ export function findNextUnique<T>(suggestion: string, existing: T[], nameGetter:
    }
    return name;
 }
+
+/** taken from the langium file, in newer Langium versions constants may be generated. */
+export const ID_REGEX = /^[_a-zA-Z@][\w_\-@/#]*$/;
+export const NPM_PACKAGE_NAME_REGEX = /^(?:(?:@(?:[a-z0-9-*~][a-z0-9-*._~]*)?\/[a-z0-9-._~])|[a-z0-9-~])[a-z0-9-._~]*$/;
+
+export function packageNameToId(input: string): string {
+   const unscoped = input.split('/').at(-1)!;
+   return unscoped.split(/[~.-]/).map(toPascal).join('');
+}


### PR DESCRIPTION
This PR adjusts the current dialog system to request all required information before creating a file.

It is an intermediate stage between the current custom dialog system and one based around reuse of the form widget to allow users to create new objects without triggering errors that make the form unusable.


## To do
 - [x] Make sure UI tests pass.
 > They behave a little differently locally, so I'm creating the PR to get CI running. Will ping when ready for review.