### PR TITLE
Feature/less restrictive grammar

### DIFF
--- a/e2e-tests/src/resources/sample-workspace/ExampleCRM/entities/Address.entity.cm
+++ b/e2e-tests/src/resources/sample-workspace/ExampleCRM/entities/Address.entity.cm
@@ -14,10 +14,14 @@ entity:
         name: "CountryCode"
         datatype: "Text"
         customProperties:
-          - name: Author
+          - id: author
+            name: "Author"
             value: "CrossBreeze"
-          - name: ExampleEntityAttribute
+          - id: exampleEntityAttribute
+            name: "ExampleEntityAttribute"
     customProperties:
-      - name: Author
+      - id: author
+        name: "Author"
         value: "CrossBreeze"
-      - name: ExampleEntity
+      - id: exampleEntity
+        name: "ExampleEntity"

--- a/examples/language-examples/logical/entities/Address.entity.cm
+++ b/examples/language-examples/logical/entities/Address.entity.cm
@@ -15,9 +15,11 @@ entity:
         datatype: "Text"
         length: 3
         customProperties:
-          - name: Author
+          - id: author
+            name: "Author"
             value: "CrossBreeze"
-          - name: ExampleEntityAttribute
+          - id: exampleEntityAttribute
+            name: "ExampleEntityAttribute"
     identifiers:
       - id: Address_Surrogate_Identifier
         name: "Address Surrogate Identifier"
@@ -25,6 +27,8 @@ entity:
         attributes:
         - Customer_Id
     customProperties:
-      - name: Author
+      - id: author
+        name: "Author"
         value: "CrossBreeze"
-      - name: ExampleEntity
+      - id: ExampleEntity
+        name: "ExampleEntity"

--- a/examples/language-examples/logical/entities/Customer.entity.cm
+++ b/examples/language-examples/logical/entities/Customer.entity.cm
@@ -43,6 +43,8 @@ entity:
         - Last_Name
         - Birth_Date
         customProperties:
-          - name: Author
+          - id: author
+            name: "Author"
             value: "CrossBreeze"
-          - name: ExampleCustomPropertyOnIdentifier
+          - id: exampleCustomPropertyOnIdentifier
+            name: "ExampleCustomPropertyOnIdentifier"

--- a/examples/language-examples/logical/relationships/Address_Customer.relationship.cm
+++ b/examples/language-examples/logical/relationships/Address_Customer.relationship.cm
@@ -9,10 +9,14 @@ relationship:
       - parent: Customer.Customer_Id
         child: Address.Customer_Id
         customProperties:
-          - name: Author
+          - id: author
+            name: "Author"
             value: "CrossBreeze"
-          - name: ExampleRelationshipAttribute
+          - id: exampleRelationshipAttribute
+            name: "ExampleRelationshipAttribute"
     customProperties:
-      - name: Author
+      - id: author
+        name: "Author"
         value: "CrossBreeze"
-      - name: ExampleRelationship
+      - id: exampleRelationship
+        name: "ExampleRelationship"

--- a/examples/language-examples/relational/tables/order.table.cm
+++ b/examples/language-examples/relational/tables/order.table.cm
@@ -48,5 +48,6 @@ table:
         columns:
           - order_number
     customProperties:
-      - name: distribution_key
+      - id: distribution_key
+        name: "Distribution Key"
         value: "customer_id"

--- a/examples/mapping-example/ExampleDWH/mappings/CompleteCustomer_Example.mapping.cm
+++ b/examples/mapping-example/ExampleDWH/mappings/CompleteCustomer_Example.mapping.cm
@@ -6,20 +6,6 @@ mapping:
         join: from
         conditions:
           - Customer.Customer_ID > 0
-      - id: Address
-        entity: ExampleCRM.Address
-        join: left-join
-        dependencies:
-          - Customer
-        conditions:
-          - Address.Customer_ID = Customer.Customer_ID
-      - id: Country
-        entity: ExampleMasterdata.Country
-        join: left-join
-        dependencies:
-          - Address
-        conditions:
-          - Country.Code = Address.Country_Code
       - id: AddressSourceObject
         entity: ExampleCRM.Address
         join: inner-join
@@ -27,6 +13,13 @@ mapping:
           - Customer
         conditions:
           - AddressSourceObject.Customer_ID = Customer.Customer_ID
+      - id: Country
+        entity: ExampleMasterdata.Country
+        join: left-join
+        dependencies:
+          - AddressSourceObject
+        conditions:
+          - Country.Code = AddressSourceObject.Country_Code
       - id: CalcAgeSourceObject
         entity: CalcAge
         join: apply

--- a/examples/mapping-example/ExampleDWH/mappings/CompleteCustomer_Example.mapping.cm
+++ b/examples/mapping-example/ExampleDWH/mappings/CompleteCustomer_Example.mapping.cm
@@ -35,9 +35,11 @@ mapping:
         conditions:
           - CalcAgeSourceObject.BirthDate = Customer.Birth_Date
         customProperties:
-          - name: Author
+          - id: author
+            name: "Author"
             value: "CrossBreeze"
-          - name: ExampleMappingSource
+          - id: exampleMappingSource
+            name: "ExampleMappingSource"
     target:
         entity: CompleteCustomer
         mappings:
@@ -58,14 +60,20 @@ mapping:
             expression: "Fixed String"
           - attribute: Today
             customProperties:
-              - name: Author
+              - id: author
+                name: "Author"
                 value: "CrossBreeze"
-              - name: ExampleEntityTargetAttribute
+              - id: exampleEntityTargetAttribute
+                name: "ExampleEntityTargetAttribute"
         customProperties:
-          - name: Author
+          - id: author
+            name: "Author"
             value: "CrossBreeze"
-          - name: ExampleMappingTarget
+          - id: exampleMappingTarget
+            name: "ExampleMappingTarget"
     customProperties:
-      - name: Author
+      - id: author
+        name: "Author"
         value: "CrossBreeze"
-      - name: ExampleMapping
+      - id: exampleMapping
+        name: "ExampleMapping"

--- a/examples/mapping-example/Sources/ExampleCRM/entities/Address.entity.cm
+++ b/examples/mapping-example/Sources/ExampleCRM/entities/Address.entity.cm
@@ -14,11 +14,6 @@ entity:
         name: "Country Code"
         datatype: "Text"
         length: 3
-        customProperties:
-          - name: Author
-            value: "CrossBreeze"
-          - name: ExampleEntityAttribute
     customProperties:
-      - name: Author
-        value: "CrossBreeze"
-      - name: ExampleEntity
+      - id: author
+        name: "Author"

--- a/examples/mapping-example/Sources/ExampleCRM/relationships/Address_Customer.relationship.cm
+++ b/examples/mapping-example/Sources/ExampleCRM/relationships/Address_Customer.relationship.cm
@@ -7,10 +7,14 @@ relationship:
       - parent: Customer.Customer_ID
         child: ExampleCRM.Address.Customer_ID
         customProperties:
-          - name: Author
+          - id: author
+            name: "Author"
             value: "CrossBreeze"
-          - name: ExampleRelationshipAttribute
+          - id: exampleRelationshipAttribute
+            name: "ExampleRelationshipAttribute"
     customProperties:
-      - name: Author
+      - id: author
+        name: "Author"
         value: "CrossBreeze"
-      - name: ExampleRelationship
+      - id: exampleRelationship
+        name: "ExampleRelationship"

--- a/examples/mapping-example/Sources/ExampleCRM/relationships/Order_Customer.relationship.cm
+++ b/examples/mapping-example/Sources/ExampleCRM/relationships/Order_Customer.relationship.cm
@@ -1,8 +1,5 @@
 relationship:
     id: Order_Customer
-    name: "Order - Customer"
-    parent: Customer
+    name: "BHoppa"
+    parent: Address
     child: Order
-    attributes:
-      - parent: Customer.Customer_ID
-        child: Order.Customer_ID

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
@@ -41,7 +41,7 @@ export class MappingEdgeCreationOperationHandler extends JsonCreateEdgeOperation
          const sourceElement = this.modelState.index.findSemanticElement(sourceElementId, isSourceObjectAttribute);
          const targetElement = this.modelState.index.findSemanticElement(targetElementId, isTargetObjectAttribute);
          const sourceEntity = <LogicalEntity | undefined>getOwner(sourceElement);
-         if (!targetElement || !targetElement.id || !sourceElement || !sourceElement.id || !sourceEntity || !sourceEntity.id) {
+         if (!targetElement?.id || !sourceElement?.id || !sourceEntity?.id) {
             return;
          }
          const sourceAttributeReference = combineIds(sourceEntity.id, sourceElement.id);

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
@@ -12,7 +12,7 @@ import {
 } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import { combineIds } from '../../../language-server/cross-model-naming.js';
-import { isSourceObjectAttribute, isTargetObjectAttribute, LogicalEntity } from '../../../language-server/generated/ast.js';
+import { isSourceObjectAttribute, isTargetObjectAttribute, SourceObject } from '../../../language-server/generated/ast.js';
 import { createAttributeMapping, createAttributeMappingSource, getOwner } from '../../../language-server/util/ast-util.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { MappingModelState } from '../model/mapping-model-state.js';
@@ -40,11 +40,11 @@ export class MappingEdgeCreationOperationHandler extends JsonCreateEdgeOperation
          const container = this.modelState.mapping.target;
          const sourceElement = this.modelState.index.findSemanticElement(sourceElementId, isSourceObjectAttribute);
          const targetElement = this.modelState.index.findSemanticElement(targetElementId, isTargetObjectAttribute);
-         const sourceEntity = <LogicalEntity | undefined>getOwner(sourceElement);
-         if (!targetElement?.id || !sourceElement?.id || !sourceEntity?.id) {
+         const sourceObject = <SourceObject>getOwner(sourceElement);
+         if (!targetElement?.id || !sourceElement?.id || !sourceObject?.id) {
             return;
          }
-         const sourceAttributeReference = combineIds(sourceEntity.id, sourceElement.id);
+         const sourceAttributeReference = combineIds(sourceObject.id, sourceElement.id);
          const existingMapping = container.mappings.find(mapping => mapping.attribute?.value.ref?.id === targetElement.id);
          if (existingMapping) {
             existingMapping.sources.push(createAttributeMappingSource(existingMapping, sourceAttributeReference));

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/handler/create-edge-operation-handler.ts
@@ -1,7 +1,7 @@
 /********************************************************************************
  * Copyright (c) 2024 CrossBreeze.
  ********************************************************************************/
-import { TARGET_ATTRIBUTE_MAPPING_EDGE_TYPE, isLeftPortId, isPortId } from '@crossbreeze/protocol';
+import { isLeftPortId, isPortId, TARGET_ATTRIBUTE_MAPPING_EDGE_TYPE } from '@crossbreeze/protocol';
 import {
    Command,
    CreateEdgeOperation,
@@ -12,7 +12,7 @@ import {
 } from '@eclipse-glsp/server';
 import { inject, injectable } from 'inversify';
 import { combineIds } from '../../../language-server/cross-model-naming.js';
-import { isSourceObjectAttribute, isTargetObjectAttribute } from '../../../language-server/generated/ast.js';
+import { isSourceObjectAttribute, isTargetObjectAttribute, LogicalEntity } from '../../../language-server/generated/ast.js';
 import { createAttributeMapping, createAttributeMappingSource, getOwner } from '../../../language-server/util/ast-util.js';
 import { CrossModelCommand } from '../../common/cross-model-command.js';
 import { MappingModelState } from '../model/mapping-model-state.js';
@@ -40,11 +40,12 @@ export class MappingEdgeCreationOperationHandler extends JsonCreateEdgeOperation
          const container = this.modelState.mapping.target;
          const sourceElement = this.modelState.index.findSemanticElement(sourceElementId, isSourceObjectAttribute);
          const targetElement = this.modelState.index.findSemanticElement(targetElementId, isTargetObjectAttribute);
-         if (!targetElement || !sourceElement) {
+         const sourceEntity = <LogicalEntity | undefined>getOwner(sourceElement);
+         if (!targetElement || !targetElement.id || !sourceElement || !sourceElement.id || !sourceEntity || !sourceEntity.id) {
             return;
          }
-         const sourceAttributeReference = combineIds(getOwner(sourceElement).id, sourceElement.id);
-         const existingMapping = container.mappings.find(mapping => mapping.attribute.value.ref?.id === targetElement.id);
+         const sourceAttributeReference = combineIds(sourceEntity.id, sourceElement.id);
+         const existingMapping = container.mappings.find(mapping => mapping.attribute?.value.ref?.id === targetElement.id);
          if (existingMapping) {
             existingMapping.sources.push(createAttributeMappingSource(existingMapping, sourceAttributeReference));
          } else {

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/layout-engine.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/layout-engine.ts
@@ -60,7 +60,7 @@ export class MappingDiagramLayoutEngine implements LayoutEngine {
 
       const idx = this.modelState.index;
       const sourceNodeOrder = [...target.mappings]
-         .sort((left, right) => (left.attribute.value.ref?.$containerIndex ?? 0) - (right.attribute.value.ref?.$containerIndex ?? 0))
+         .sort((left, right) => (left.attribute?.value.ref?.$containerIndex ?? 0) - (right.attribute?.value.ref?.$containerIndex ?? 0))
          .flatMap(mapping => mapping.sources.map(source => idx.createId(getOwner(source.value.ref))));
       return (left: GNode, right: GNode): number => {
          if (!sourceNodeOrder.includes(left.id)) {

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/mapping-model-state.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/mapping-model-state.ts
@@ -22,13 +22,15 @@ export class MappingModelState extends CrossModelState {
          const targetAttributes = target ? getAttributes(target) : [];
          // we want to ensure that each target attribute has a mapping that we can manipulate in our editor
          // the change will automatically be persisted with the next change that is done
-         targetAttributes.forEach(targetAttribute => {
-            if (!target.mappings.find(mapping => mapping.attribute.value.ref === targetAttribute)) {
-               const mapping = createAttributeMapping(target, undefined, targetAttribute.id);
-               (mapping.attribute.value as any).ref = targetAttribute;
-               target.mappings.push(mapping);
-            }
-         });
+         targetAttributes
+            .filter(targetAttribute => targetAttribute.id !== undefined)
+            .forEach(targetAttribute => {
+               if (!target.mappings.find(mapping => mapping.attribute?.value.ref === targetAttribute)) {
+                  const mapping = createAttributeMapping(target, undefined, targetAttribute.id!);
+                  (mapping.attribute?.value as any).ref = targetAttribute;
+                  target.mappings.push(mapping);
+               }
+            });
       }
    }
 

--- a/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/nodes.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/mapping-diagram/model/nodes.ts
@@ -71,7 +71,7 @@ export class GTargetObjectNodeBuilder extends GNodeBuilder<GTargetObjectNode> {
       const attributesContainer = new AttributesCompartmentBuilder().set(id);
       for (const attribute of attributes) {
          const attrComp = AttributeCompartment.builder().set(attribute, index, (attr, attrId) => this.markExpression(node, attr, attrId));
-         const mappingIdx = node.mappings.findIndex(mapping => mapping.attribute.value.ref === attribute);
+         const mappingIdx = node.mappings.findIndex(mapping => mapping.attribute?.value.ref === attribute);
          if (mappingIdx >= 0) {
             attrComp.addArg(RenderProps.TARGET_ATTRIBUTE_MAPPING_IDX, mappingIdx);
          }
@@ -84,7 +84,7 @@ export class GTargetObjectNodeBuilder extends GNodeBuilder<GTargetObjectNode> {
    }
 
    protected markExpression(node: TargetObject, attribute: TargetObjectAttribute, id: string): GLabel | undefined {
-      return node.mappings.some(mapping => mapping.attribute.value.ref === attribute && !!mapping.expression)
+      return node.mappings.some(mapping => mapping.attribute?.value.ref === attribute && !!mapping.expression)
          ? GLabel.builder().id(`${id}_attribute_expression_marker`).text('𝑓ᵪ').addCssClasses('attribute_expression_marker').build()
          : undefined;
    }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/edge-checker/edge-checker.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/edge-checker/edge-checker.ts
@@ -40,6 +40,10 @@ export class SystemEdgeCreationChecker implements EdgeCreationChecker {
       });
 
       const superEntityGlobalId = this.modelState.idProvider.getGlobalId(superEntityNode.entity.ref)!;
+      // If the id of the super entity is missing, we don't allow the edge creation
+      if (!superEntityNode.entity.ref.id) {
+         return false;
+      }
       const isInScope = scope.elementScope.getElement(superEntityNode.entity.ref.id) ?? scope.elementScope.getElement(superEntityGlobalId);
       if (!isInScope) {
          return false;

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-inheritance-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-inheritance-operation-handler.ts
@@ -54,6 +54,10 @@ export class SystemDiagramCreateInheritanceOperationHandler extends JsonCreateEd
       });
 
       const superEntityGlobalId = this.modelState.idProvider.getGlobalId(superEntityNode.entity.ref)!;
+      // If the id of the super entity is not set yet, we can't create an inheritance.
+      if (!superEntityNode.entity.ref.id) {
+         return undefined;
+      }
       const isInScope = scope.elementScope.getElement(superEntityNode.entity.ref.id) ?? scope.elementScope.getElement(superEntityGlobalId);
       if (!isInScope) {
          return undefined;
@@ -78,7 +82,7 @@ export class SystemDiagramCreateInheritanceOperationHandler extends JsonCreateEd
       };
       this.modelState.systemDiagram.edges.push(edge);
       this.actionDispatcher.dispatchAfterNextUpdate(
-         SelectAction.create({ selectedElementsIDs: [this.modelState.idProvider.getLocalId(edge) ?? edge.id] })
+         SelectAction.create({ selectedElementsIDs: [this.modelState.idProvider.getLocalId(edge) ?? edge.id!] })
       );
    }
 }

--- a/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-relationship-operation-handler.ts
+++ b/extensions/crossmodel-lang/src/glsp-server/system-diagram/handler/create-relationship-operation-handler.ts
@@ -57,7 +57,7 @@ export class SystemDiagramCreateRelationshipOperationHandler extends JsonCreateE
             };
             this.modelState.systemDiagram.edges.push(edge);
             this.actionDispatcher.dispatchAfterNextUpdate(
-               SelectAction.create({ selectedElementsIDs: [this.modelState.idProvider.getLocalId(edge) ?? edge.id] })
+               SelectAction.create({ selectedElementsIDs: [this.modelState.idProvider.getLocalId(edge) ?? edge.id!] })
             );
          }
       }

--- a/extensions/crossmodel-lang/src/language-server/cross-model-naming.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-naming.ts
@@ -80,6 +80,8 @@ export class DefaultIdProvider implements NameProvider, IdProvider {
          return undefined;
       }
       let parent = this.getParent(node);
+      // Recurse through the parents to get the full local id.
+      // For example for custom property of an attribute its <entity-id.attribute-id.custom-property-id).
       while (parent) {
          const parentId = this.getNodeId(parent);
          if (parentId) {

--- a/extensions/crossmodel-lang/src/language-server/cross-model-scope-provider.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-scope-provider.ts
@@ -219,7 +219,12 @@ export class CrossModelScopeProvider extends PackageScopeProvider {
             return description.name.startsWith(container.$container.parent?.$refText + '.');
          }
       }
-      if (isSourceObject(container) && property === 'entity' && container.$container.target.entity.ref) {
+      if (
+         isSourceObject(container) &&
+         property === 'entity' &&
+         container.$container.target.entity &&
+         container.$container.target.entity.ref
+      ) {
          const targetEntity = container.$container.target.entity.ref;
          if (description instanceof GlobalAstNodeDescription) {
             return description.name !== this.idProvider.getGlobalId(targetEntity);

--- a/extensions/crossmodel-lang/src/language-server/cross-model-scope.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-scope.ts
@@ -143,10 +143,12 @@ export class CrossModelScopeComputation extends DefaultScopeComputation {
             setOwner({ ...attribute, $type: LogicalEntityNodeAttribute }, node)
          ) ?? [];
       setAttributes(node, attributes);
-      return attributes.map(attribute => this.descriptions.createDescription(attribute, combineIds(nodeId, attribute.id), document));
+      return attributes
+         .filter(attribute => attribute.id !== undefined) // Only process attributes with an id
+         .map(attribute => this.descriptions.createDescription(attribute, combineIds(nodeId, attribute.id!), document));
    }
 
-   protected getLogicalEntity(node: AstNode & { entity: Reference<LogicalEntity> }, document: LangiumDocument): LogicalEntity | undefined {
+   protected getLogicalEntity(node: AstNode & { entity?: Reference<LogicalEntity> }, document: LangiumDocument): LogicalEntity | undefined {
       try {
          return fixDocument(node, document).entity?.ref;
       } catch (error) {
@@ -163,7 +165,9 @@ export class CrossModelScopeComputation extends DefaultScopeComputation {
       const attributes =
          entity.attributes.map<SourceObjectAttribute>(attribute => setOwner({ ...attribute, $type: SourceObjectAttribute }, node)) ?? [];
       setAttributes(node, attributes);
-      return attributes.map(attribute => this.descriptions.createDescription(attribute, combineIds(nodeId, attribute.id), document));
+      return attributes
+         .filter(attribute => attribute.id !== undefined) // Ensure attribute.id is defined
+         .map(attribute => this.descriptions.createDescription(attribute, combineIds(nodeId, attribute.id!), document));
    }
 
    protected processTargetObject(node: TargetObject, nodeId: string, document: LangiumDocument): AstNodeDescription[] {

--- a/extensions/crossmodel-lang/src/language-server/cross-model-serializer.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-serializer.ts
@@ -12,7 +12,6 @@ import {
    InheritanceEdge,
    isAttributeMappingSource,
    isAttributeMappingTarget,
-   isCustomProperty,
    isJoinCondition,
    isLogicalAttribute,
    isRelationship,
@@ -113,7 +112,6 @@ export class CrossModelSerializer implements Serializer<CrossModelRoot> {
          (key === 'superEntities' && Array.isArray(parent)) ||
          propertyOf(parent, key, isRelationship, 'parentCardinality') ||
          propertyOf(parent, key, isRelationship, 'childCardinality') ||
-         propertyOf(parent, key, isCustomProperty, 'name') ||
          propertyOf(parent, key, isSourceObject, 'join') ||
          (!Array.isArray(value) && this.isValidReference(parent, key, value))
       ) {

--- a/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
@@ -23,7 +23,6 @@ import {
    isLogicalEntity,
    isMapping,
    isSystemDiagram,
-   isWithCustomProperties,
    LogicalAttribute,
    LogicalEntity,
    Mapping,
@@ -35,7 +34,8 @@ import {
    SourceObjectCondition,
    SourceObjectDependency,
    TargetObject,
-   TargetObjectAttribute
+   TargetObjectAttribute,
+   WithCustomProperties
 } from './generated/ast.js';
 import { findDocument, getOwner, getSemanticRootFromAstRoot, isSemanticRoot } from './util/ast-util.js';
 
@@ -75,7 +75,8 @@ export function registerValidationChecks(services: CrossModelServices): void {
       SourceObjectCondition: validator.checkSourceObjectCondition,
       SourceObjectDependency: validator.checkSourceObjectDependency,
       TargetObject: validator.checkTargetObject,
-      NamedObject: validator.checkNamedObject
+      NamedObject: validator.checkNamedObject,
+      WithCustomProperties: validator.checkUniqueCustomerPropertyId
    };
    registry.register(checks, validator);
 }
@@ -157,9 +158,10 @@ export class CrossModelValidator {
       if (isMapping(node)) {
          this.markDuplicateIds(node.sources, accept);
       }
-      if (isWithCustomProperties(node)) {
-         this.markDuplicateIds(node.customProperties, accept);
-      }
+   }
+
+   checkUniqueCustomerPropertyId(node: WithCustomProperties, accept: ValidationAcceptor): void {
+      this.markDuplicateIds(node.customProperties, accept);
    }
 
    protected markDuplicateIds(nodes: IdentifiableAstNode[], accept: ValidationAcceptor): void {

--- a/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
@@ -96,7 +96,7 @@ export class CrossModelValidator {
       if (identifiedObject.id === undefined || identifiedObject.id.length === 0) {
          accept('error', 'The id cannot be empty', { node: identifiedObject, property: 'id' });
       } else {
-         // Only perform the following checks when the id is know.
+         // Only perform the following checks when the id is known
          this.checkUniqueGlobalId(identifiedObject, accept);
          this.checkUniqueLocalId(identifiedObject, accept);
          this.checkMatchingFilename(identifiedObject, accept);

--- a/extensions/crossmodel-lang/src/language-server/generated/ast.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/ast.ts
@@ -172,22 +172,9 @@ export function isCrossModelRoot(item: unknown): item is CrossModelRoot {
     return reflection.isInstance(item, CrossModelRoot);
 }
 
-export interface CustomProperty extends AstNode {
-    readonly $container: WithCustomProperties;
-    readonly $type: 'CustomProperty';
-    name: string;
-    value?: string;
-}
-
-export const CustomProperty = 'CustomProperty';
-
-export function isCustomProperty(item: unknown): item is CustomProperty {
-    return reflection.isInstance(item, CustomProperty);
-}
-
 export interface IdentifiedObject extends AstNode {
-    readonly $type: 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'DataElementContainerMapping' | 'DataElementMapping' | 'IdentifiedObject' | 'InheritanceEdge' | 'LogicalAttribute' | 'LogicalEntity' | 'LogicalEntityNode' | 'LogicalEntityNodeAttribute' | 'LogicalIdentifier' | 'Mapping' | 'NamedObject' | 'Relationship' | 'RelationshipEdge' | 'SourceDataElementContainer' | 'SourceObject' | 'SourceObjectAttribute' | 'SystemDiagram' | 'SystemDiagramEdge' | 'TargetObjectAttribute';
-    id: string;
+    readonly $type: 'CustomProperty' | 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'DataElementContainerMapping' | 'DataElementMapping' | 'IdentifiedObject' | 'InheritanceEdge' | 'LogicalAttribute' | 'LogicalEntity' | 'LogicalEntityNode' | 'LogicalEntityNodeAttribute' | 'LogicalIdentifier' | 'Mapping' | 'NamedObject' | 'Relationship' | 'RelationshipEdge' | 'SourceDataElementContainer' | 'SourceObject' | 'SourceObjectAttribute' | 'SystemDiagram' | 'SystemDiagramEdge' | 'TargetObjectAttribute';
+    id?: string;
 }
 
 export const IdentifiedObject = 'IdentifiedObject';
@@ -305,9 +292,9 @@ export function isLogicalEntityNode(item: unknown): item is LogicalEntityNode {
 }
 
 export interface NamedObject extends IdentifiedObject {
-    readonly $type: 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'LogicalAttribute' | 'LogicalEntity' | 'LogicalEntityNodeAttribute' | 'LogicalIdentifier' | 'NamedObject' | 'Relationship' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
+    readonly $type: 'CustomProperty' | 'DataElement' | 'DataElementContainer' | 'DataElementContainerLink' | 'LogicalAttribute' | 'LogicalEntity' | 'LogicalEntityNodeAttribute' | 'LogicalIdentifier' | 'NamedObject' | 'Relationship' | 'SourceObjectAttribute' | 'TargetObjectAttribute';
     description?: string;
-    name: string;
+    name?: string;
 }
 
 export const NamedObject = 'NamedObject';
@@ -353,7 +340,7 @@ export function isSystemDiagramEdge(item: unknown): item is SystemDiagramEdge {
 export interface AttributeMapping extends WithCustomProperties {
     readonly $container: TargetObject;
     readonly $type: 'AttributeMapping';
-    attribute: AttributeMappingTarget;
+    attribute?: AttributeMappingTarget;
     expression: string;
     sources: Array<AttributeMappingSource>;
 }
@@ -422,10 +409,10 @@ export interface Relationship extends DataElementContainerLink, WithCustomProper
     readonly $container: CrossModelRoot;
     readonly $type: 'Relationship';
     attributes: Array<RelationshipAttribute>;
-    child: Reference<LogicalEntity>;
+    child?: Reference<LogicalEntity>;
     childCardinality?: string;
     childRole?: string;
-    parent: Reference<LogicalEntity>;
+    parent?: Reference<LogicalEntity>;
     parentCardinality?: string;
     parentRole?: string;
 }
@@ -439,8 +426,8 @@ export function isRelationship(item: unknown): item is Relationship {
 export interface RelationshipAttribute extends WithCustomProperties {
     readonly $container: Relationship;
     readonly $type: 'RelationshipAttribute';
-    child: Reference<LogicalAttribute>;
-    parent: Reference<LogicalAttribute>;
+    child?: Reference<LogicalAttribute>;
+    parent?: Reference<LogicalAttribute>;
 }
 
 export const RelationshipAttribute = 'RelationshipAttribute';
@@ -454,8 +441,8 @@ export interface SourceObject extends SourceDataElementContainer, WithCustomProp
     readonly $type: 'SourceObject';
     conditions: Array<SourceObjectCondition>;
     dependencies: Array<SourceObjectDependency>;
-    entity: Reference<LogicalEntity>;
-    join: string;
+    entity?: Reference<LogicalEntity>;
+    join?: string;
 }
 
 export const SourceObject = 'SourceObject';
@@ -467,7 +454,7 @@ export function isSourceObject(item: unknown): item is SourceObject {
 export interface TargetObject extends WithCustomProperties {
     readonly $container: Mapping;
     readonly $type: 'TargetObject';
-    entity: Reference<LogicalEntity>;
+    entity?: Reference<LogicalEntity>;
     mappings: Array<AttributeMapping>;
 }
 
@@ -475,6 +462,18 @@ export const TargetObject = 'TargetObject';
 
 export function isTargetObject(item: unknown): item is TargetObject {
     return reflection.isInstance(item, TargetObject);
+}
+
+export interface CustomProperty extends NamedObject {
+    readonly $container: WithCustomProperties;
+    readonly $type: 'CustomProperty';
+    value?: string;
+}
+
+export const CustomProperty = 'CustomProperty';
+
+export function isCustomProperty(item: unknown): item is CustomProperty {
+    return reflection.isInstance(item, CustomProperty);
 }
 
 export interface DataElement extends NamedObject {
@@ -619,6 +618,7 @@ export class CrossModelAstReflection extends AbstractAstReflection {
             case TargetObject: {
                 return this.isSubtype(WithCustomProperties, supertype);
             }
+            case CustomProperty:
             case DataElement:
             case DataElementContainer:
             case DataElementContainerLink: {
@@ -751,15 +751,6 @@ export class CrossModelAstReflection extends AbstractAstReflection {
                         { name: 'mapping' },
                         { name: 'relationship' },
                         { name: 'systemDiagram' }
-                    ]
-                };
-            }
-            case CustomProperty: {
-                return {
-                    name: CustomProperty,
-                    properties: [
-                        { name: 'name' },
-                        { name: 'value' }
                     ]
                 };
             }
@@ -997,6 +988,17 @@ export class CrossModelAstReflection extends AbstractAstReflection {
                         { name: 'customProperties', defaultValue: [] },
                         { name: 'entity' },
                         { name: 'mappings', defaultValue: [] }
+                    ]
+                };
+            }
+            case CustomProperty: {
+                return {
+                    name: CustomProperty,
+                    properties: [
+                        { name: 'description' },
+                        { name: 'id' },
+                        { name: 'name' },
+                        { name: 'value' }
                     ]
                 };
             }

--- a/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
@@ -763,7 +763,8 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/rules@6"
               },
               "arguments": []
-            }
+            },
+            "cardinality": "?"
           }
         ]
       },
@@ -791,24 +792,30 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "arguments": []
           },
           {
-            "$type": "Keyword",
-            "value": "name"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "name",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@4"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "name"
               },
-              "arguments": []
-            }
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "name",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@4"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "?"
           },
           {
             "$type": "Group",
@@ -911,29 +918,19 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
     },
     {
       "$type": "ParserRule",
-      "name": "CustomProperty",
+      "name": "CustomPropertyFragment",
+      "returnType": {
+        "$ref": "#/interfaces@12"
+      },
       "definition": {
         "$type": "Group",
         "elements": [
           {
-            "$type": "Keyword",
-            "value": "name"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "name",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@6"
-              },
-              "arguments": []
-            }
+            "$type": "RuleCall",
+            "rule": {
+              "$ref": "#/rules@15"
+            },
+            "arguments": []
           },
           {
             "$type": "Group",
@@ -1002,7 +999,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "Relationship",
       "returnType": {
-        "$ref": "#/interfaces@12"
+        "$ref": "#/interfaces@13"
       },
       "definition": {
         "$type": "Group",
@@ -1030,31 +1027,37 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "arguments": []
           },
           {
-            "$type": "Keyword",
-            "value": "parent"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "parent",
-            "operator": "=",
-            "terminal": {
-              "$type": "CrossReference",
-              "type": {
-                "$ref": "#/interfaces@0"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "parent"
               },
-              "terminal": {
-                "$type": "RuleCall",
-                "rule": {
-                  "$ref": "#/rules@7"
-                },
-                "arguments": []
+              {
+                "$type": "Keyword",
+                "value": ":"
               },
-              "deprecatedSyntax": false
-            }
+              {
+                "$type": "Assignment",
+                "feature": "parent",
+                "operator": "=",
+                "terminal": {
+                  "$type": "CrossReference",
+                  "type": {
+                    "$ref": "#/interfaces@0"
+                  },
+                  "terminal": {
+                    "$type": "RuleCall",
+                    "rule": {
+                      "$ref": "#/rules@7"
+                    },
+                    "arguments": []
+                  },
+                  "deprecatedSyntax": false
+                }
+              }
+            ],
+            "cardinality": "?"
           },
           {
             "$type": "Group",
@@ -1109,31 +1112,37 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "cardinality": "?"
           },
           {
-            "$type": "Keyword",
-            "value": "child"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "child",
-            "operator": "=",
-            "terminal": {
-              "$type": "CrossReference",
-              "type": {
-                "$ref": "#/interfaces@0"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "child"
               },
-              "terminal": {
-                "$type": "RuleCall",
-                "rule": {
-                  "$ref": "#/rules@7"
-                },
-                "arguments": []
+              {
+                "$type": "Keyword",
+                "value": ":"
               },
-              "deprecatedSyntax": false
-            }
+              {
+                "$type": "Assignment",
+                "feature": "child",
+                "operator": "=",
+                "terminal": {
+                  "$type": "CrossReference",
+                  "type": {
+                    "$ref": "#/interfaces@0"
+                  },
+                  "terminal": {
+                    "$type": "RuleCall",
+                    "rule": {
+                      "$ref": "#/rules@7"
+                    },
+                    "arguments": []
+                  },
+                  "deprecatedSyntax": false
+                }
+              }
+            ],
+            "cardinality": "?"
           },
           {
             "$type": "Group",
@@ -1268,7 +1277,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "RelationshipAttribute",
       "returnType": {
-        "$ref": "#/interfaces@13"
+        "$ref": "#/interfaces@14"
       },
       "definition": {
         "$type": "Group",
@@ -1298,7 +1307,8 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "arguments": []
               },
               "deprecatedSyntax": false
-            }
+            },
+            "cardinality": "?"
           },
           {
             "$type": "Keyword",
@@ -1325,7 +1335,8 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "arguments": []
               },
               "deprecatedSyntax": false
-            }
+            },
+            "cardinality": "?"
           },
           {
             "$type": "RuleCall",
@@ -1348,7 +1359,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "SystemDiagram",
       "returnType": {
-        "$ref": "#/interfaces@14"
+        "$ref": "#/interfaces@15"
       },
       "definition": {
         "$type": "Group",
@@ -1510,7 +1521,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "LogicalEntityNode",
       "returnType": {
-        "$ref": "#/interfaces@15"
+        "$ref": "#/interfaces@16"
       },
       "definition": {
         "$type": "Group",
@@ -1642,7 +1653,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "SystemDiagramEdge",
       "returnType": {
-        "$ref": "#/interfaces@17"
+        "$ref": "#/interfaces@18"
       },
       "definition": {
         "$type": "Alternatives",
@@ -1674,7 +1685,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "RelationshipEdge",
       "returnType": {
-        "$ref": "#/interfaces@18"
+        "$ref": "#/interfaces@19"
       },
       "definition": {
         "$type": "Group",
@@ -1701,7 +1712,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@12"
+                "$ref": "#/interfaces@13"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -1728,7 +1739,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -1755,7 +1766,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -1780,7 +1791,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "InheritanceEdge",
       "returnType": {
-        "$ref": "#/interfaces@19"
+        "$ref": "#/interfaces@20"
       },
       "definition": {
         "$type": "Group",
@@ -1807,7 +1818,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -1834,7 +1845,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "terminal": {
               "$type": "CrossReference",
               "type": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               },
               "terminal": {
                 "$type": "RuleCall",
@@ -1859,7 +1870,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "Mapping",
       "returnType": {
-        "$ref": "#/interfaces@22"
+        "$ref": "#/interfaces@23"
       },
       "definition": {
         "$type": "Group",
@@ -1940,24 +1951,30 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "cardinality": "?"
           },
           {
-            "$type": "Keyword",
-            "value": "target"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "target",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@34"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "target"
               },
-              "arguments": []
-            }
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "target",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@34"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "?"
           },
           {
             "$type": "RuleCall",
@@ -1987,7 +2004,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "SourceObject",
       "returnType": {
-        "$ref": "#/interfaces@23"
+        "$ref": "#/interfaces@24"
       },
       "definition": {
         "$type": "Group",
@@ -2000,51 +2017,63 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "arguments": []
           },
           {
-            "$type": "Keyword",
-            "value": "entity"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "entity",
-            "operator": "=",
-            "terminal": {
-              "$type": "CrossReference",
-              "type": {
-                "$ref": "#/interfaces@0"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "entity"
               },
-              "terminal": {
-                "$type": "RuleCall",
-                "rule": {
-                  "$ref": "#/rules@7"
-                },
-                "arguments": []
+              {
+                "$type": "Keyword",
+                "value": ":"
               },
-              "deprecatedSyntax": false
-            }
+              {
+                "$type": "Assignment",
+                "feature": "entity",
+                "operator": "=",
+                "terminal": {
+                  "$type": "CrossReference",
+                  "type": {
+                    "$ref": "#/interfaces@0"
+                  },
+                  "terminal": {
+                    "$type": "RuleCall",
+                    "rule": {
+                      "$ref": "#/rules@7"
+                    },
+                    "arguments": []
+                  },
+                  "deprecatedSyntax": false
+                }
+              }
+            ],
+            "cardinality": "?"
           },
           {
-            "$type": "Keyword",
-            "value": "join"
-          },
-          {
-            "$type": "Keyword",
-            "value": ":"
-          },
-          {
-            "$type": "Assignment",
-            "feature": "join",
-            "operator": "=",
-            "terminal": {
-              "$type": "RuleCall",
-              "rule": {
-                "$ref": "#/rules@28"
+            "$type": "Group",
+            "elements": [
+              {
+                "$type": "Keyword",
+                "value": "join"
               },
-              "arguments": []
-            }
+              {
+                "$type": "Keyword",
+                "value": ":"
+              },
+              {
+                "$type": "Assignment",
+                "feature": "join",
+                "operator": "=",
+                "terminal": {
+                  "$type": "RuleCall",
+                  "rule": {
+                    "$ref": "#/rules@28"
+                  },
+                  "arguments": []
+                }
+              }
+            ],
+            "cardinality": "?"
           },
           {
             "$type": "Group",
@@ -2215,7 +2244,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/interfaces@23"
+            "$ref": "#/interfaces@24"
           },
           "terminal": {
             "$type": "RuleCall",
@@ -2421,7 +2450,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "terminal": {
                   "$type": "CrossReference",
                   "type": {
-                    "$ref": "#/interfaces@20"
+                    "$ref": "#/interfaces@21"
                   },
                   "terminal": {
                     "$type": "RuleCall",
@@ -2448,7 +2477,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "TargetObject",
       "returnType": {
-        "$ref": "#/interfaces@24"
+        "$ref": "#/interfaces@25"
       },
       "definition": {
         "$type": "Group",
@@ -2485,7 +2514,8 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "arguments": []
               },
               "deprecatedSyntax": false
-            }
+            },
+            "cardinality": "?"
           },
           {
             "$type": "Group",
@@ -2568,7 +2598,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "$type": "ParserRule",
       "name": "AttributeMapping",
       "returnType": {
-        "$ref": "#/interfaces@25"
+        "$ref": "#/interfaces@26"
       },
       "definition": {
         "$type": "Group",
@@ -2591,7 +2621,8 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/rules@36"
               },
               "arguments": []
-            }
+            },
+            "cardinality": "?"
           },
           {
             "$type": "Group",
@@ -2699,7 +2730,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/interfaces@21"
+            "$ref": "#/interfaces@22"
           },
           "terminal": {
             "$type": "RuleCall",
@@ -2728,7 +2759,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         "terminal": {
           "$type": "CrossReference",
           "type": {
-            "$ref": "#/interfaces@20"
+            "$ref": "#/interfaces@21"
           },
           "terminal": {
             "$type": "RuleCall",
@@ -2907,11 +2938,11 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "id",
+          "isOptional": true,
           "type": {
             "$type": "SimpleType",
             "primitiveType": "string"
-          },
-          "isOptional": false
+          }
         }
       ],
       "superTypes": []
@@ -2928,11 +2959,11 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "name",
+          "isOptional": true,
           "type": {
             "$type": "SimpleType",
             "primitiveType": "string"
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",
@@ -3027,7 +3058,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/rules@17"
+                "$ref": "#/interfaces@12"
               }
             }
           },
@@ -3035,6 +3066,26 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         }
       ],
       "superTypes": []
+    },
+    {
+      "$type": "Interface",
+      "name": "CustomProperty",
+      "superTypes": [
+        {
+          "$ref": "#/interfaces@4"
+        }
+      ],
+      "attributes": [
+        {
+          "$type": "TypeAttribute",
+          "name": "value",
+          "isOptional": true,
+          "type": {
+            "$type": "SimpleType",
+            "primitiveType": "string"
+          }
+        }
+      ]
     },
     {
       "$type": "Interface",
@@ -3051,6 +3102,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "parent",
+          "isOptional": true,
           "type": {
             "$type": "ReferenceType",
             "referenceType": {
@@ -3059,8 +3111,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/interfaces@0"
               }
             }
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",
@@ -3083,6 +3134,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "child",
+          "isOptional": true,
           "type": {
             "$type": "ReferenceType",
             "referenceType": {
@@ -3091,8 +3143,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/interfaces@0"
               }
             }
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",
@@ -3120,7 +3171,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@13"
+                "$ref": "#/interfaces@14"
               }
             }
           },
@@ -3140,6 +3191,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "parent",
+          "isOptional": true,
           "type": {
             "$type": "ReferenceType",
             "referenceType": {
@@ -3148,12 +3200,12 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/interfaces@1"
               }
             }
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",
           "name": "child",
+          "isOptional": true,
           "type": {
             "$type": "ReferenceType",
             "referenceType": {
@@ -3162,8 +3214,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/interfaces@1"
               }
             }
-          },
-          "isOptional": false
+          }
         }
       ]
     },
@@ -3184,7 +3235,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               }
             }
           },
@@ -3198,7 +3249,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@17"
+                "$ref": "#/interfaces@18"
               }
             }
           },
@@ -3292,7 +3343,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "RelationshipEdge",
       "superTypes": [
         {
-          "$ref": "#/interfaces@17"
+          "$ref": "#/interfaces@18"
         }
       ],
       "attributes": [
@@ -3304,7 +3355,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@12"
+                "$ref": "#/interfaces@13"
               }
             }
           },
@@ -3318,7 +3369,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               }
             }
           },
@@ -3332,7 +3383,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               }
             }
           },
@@ -3345,7 +3396,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
       "name": "InheritanceEdge",
       "superTypes": [
         {
-          "$ref": "#/interfaces@17"
+          "$ref": "#/interfaces@18"
         }
       ],
       "attributes": [
@@ -3357,7 +3408,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               }
             }
           },
@@ -3371,7 +3422,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "referenceType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@15"
+                "$ref": "#/interfaces@16"
               }
             }
           },
@@ -3419,7 +3470,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@23"
+                "$ref": "#/interfaces@24"
               }
             }
           },
@@ -3431,7 +3482,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
           "type": {
             "$type": "SimpleType",
             "typeRef": {
-              "$ref": "#/interfaces@24"
+              "$ref": "#/interfaces@25"
             }
           },
           "isOptional": false
@@ -3453,6 +3504,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "entity",
+          "isOptional": true,
           "type": {
             "$type": "ReferenceType",
             "referenceType": {
@@ -3461,17 +3513,16 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/interfaces@0"
               }
             }
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",
           "name": "join",
+          "isOptional": true,
           "type": {
             "$type": "SimpleType",
             "primitiveType": "string"
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",
@@ -3515,6 +3566,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "entity",
+          "isOptional": true,
           "type": {
             "$type": "ReferenceType",
             "referenceType": {
@@ -3523,8 +3575,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 "$ref": "#/interfaces@0"
               }
             }
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",
@@ -3534,7 +3585,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
             "elementType": {
               "$type": "SimpleType",
               "typeRef": {
-                "$ref": "#/interfaces@25"
+                "$ref": "#/interfaces@26"
               }
             }
           },
@@ -3554,13 +3605,13 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
         {
           "$type": "TypeAttribute",
           "name": "attribute",
+          "isOptional": true,
           "type": {
             "$type": "SimpleType",
             "typeRef": {
               "$ref": "#/rules@36"
             }
-          },
-          "isOptional": false
+          }
         },
         {
           "$type": "TypeAttribute",

--- a/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
+++ b/extensions/crossmodel-lang/src/language-server/generated/grammar.ts
@@ -899,7 +899,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
                 }
               }
             ],
-            "cardinality": "*"
+            "cardinality": "+"
           },
           {
             "$type": "RuleCall",
@@ -918,7 +918,7 @@ export const CrossModelGrammar = (): Grammar => loadedCrossModelGrammar ?? (load
     },
     {
       "$type": "ParserRule",
-      "name": "CustomPropertyFragment",
+      "name": "CustomProperty",
       "returnType": {
         "$ref": "#/interfaces@12"
       },

--- a/extensions/crossmodel-lang/src/language-server/grammar/common.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/common.langium
@@ -49,7 +49,7 @@ interface WithCustomProperties {
 fragment CustomPropertiesFragment returns WithCustomProperties:
     'customProperties' ':'
         INDENT
-            (LIST_ITEM customProperties+=CustomPropertyFragment)*
+            (LIST_ITEM customProperties+=CustomProperty)+
         DEDENT
     ;
 
@@ -57,6 +57,6 @@ interface CustomProperty extends NamedObject {
     value?: string;
 }
 
-CustomPropertyFragment returns CustomProperty:
+CustomProperty returns CustomProperty:
     NamedObjectFragment
     ('value' ':' value=STRING)?;

--- a/extensions/crossmodel-lang/src/language-server/grammar/common.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/common.langium
@@ -3,20 +3,20 @@ import 'terminals'
 // Common interfaces and fragments.
 
 interface IdentifiedObject {
-    id: string;
+    id?: string;
 }
 
 fragment IdentifiedObjectFragment returns IdentifiedObject:
-    'id' ':' id=ID;
+    'id' ':' (id=ID)?;
 
 interface NamedObject extends IdentifiedObject {
-    name: string;
+    name?: string;
     description?: string;
 }
 
 fragment NamedObjectFragment returns NamedObject:
     IdentifiedObjectFragment
-    'name' ':' name=STRING
+    ('name' ':' name=STRING)?
     ('description' ':' description=STRING)?
 ;
 
@@ -49,10 +49,14 @@ interface WithCustomProperties {
 fragment CustomPropertiesFragment returns WithCustomProperties:
     'customProperties' ':'
         INDENT
-            (LIST_ITEM customProperties+=CustomProperty)*
+            (LIST_ITEM customProperties+=CustomPropertyFragment)*
         DEDENT
     ;
 
-CustomProperty:
-    'name' ':' name=ID
+interface CustomProperty extends NamedObject {
+    value?: string;
+}
+
+CustomPropertyFragment returns CustomProperty:
+    NamedObjectFragment
     ('value' ':' value=STRING)?;

--- a/extensions/crossmodel-lang/src/language-server/grammar/entity.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/entity.langium
@@ -44,7 +44,7 @@ LogicalAttribute returns LogicalAttribute:
     ('length' ':' length=NUMBER)?
     ('precision' ':' precision=NUMBER)?
     ('scale' ':' scale=NUMBER)?
-    (identifier?='identifier' ':' ('TRUE' | 'true'))?
+    (identifier?='identifier' ':' ('TRUE' | 'true'))? // To-be removed in future (identifiers collection on entity is replacement for this information).
     CustomPropertiesFragment?
 ;
 

--- a/extensions/crossmodel-lang/src/language-server/grammar/mapping.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/mapping.langium
@@ -23,22 +23,22 @@ Mapping returns Mapping:
                     (LIST_ITEM sources+=SourceObject)+
                 DEDENT
             )?
-            'target' ':' target=TargetObject
+            ('target' ':' target=TargetObject)?
             CustomPropertiesFragment?
         DEDENT
 ;
 
 interface SourceObject extends SourceDataElementContainer, WithCustomProperties {
-    entity: @LogicalEntity;
-    join: string;
+    entity?: @LogicalEntity;
+    join?: string;
     dependencies: SourceObjectDependency[]
     conditions: SourceObjectCondition[]
 }
 
 SourceObject returns SourceObject:
     IdentifiedObjectFragment
-    'entity' ':' entity=[LogicalEntity:IDReference] // implies attributes through entity
-    'join' ':' join=JoinType
+    ('entity' ':' entity=[LogicalEntity:IDReference])? // implies attributes through entity
+    ('join' ':' join=JoinType)?
     ('dependencies' ':'
         INDENT
             (LIST_ITEM dependencies+=SourceObjectDependency)*
@@ -75,13 +75,13 @@ PrimaryExpression infers BooleanExpression:
 ;
 
 interface TargetObject extends WithCustomProperties {
-    entity: @LogicalEntity;
+    entity?: @LogicalEntity;
     mappings: AttributeMapping[];
 }
 
 TargetObject returns TargetObject:
     INDENT
-        'entity' ':' entity=[LogicalEntity:IDReference] // implies attributes through entity
+        'entity' ':' (entity=[LogicalEntity:IDReference])? // implies attributes through entity
         ('mappings' ':'
             INDENT 
                 (LIST_ITEM mappings+=AttributeMapping)+     
@@ -92,13 +92,13 @@ TargetObject returns TargetObject:
 ;
 
 interface AttributeMapping extends WithCustomProperties {
-    attribute: AttributeMappingTarget;
+    attribute?: AttributeMappingTarget;
     sources: AttributeMappingSource[];
     expression: string;
 }
 
 AttributeMapping returns AttributeMapping:
-    'attribute' ':' attribute=AttributeMappingTarget
+    'attribute' ':' (attribute=AttributeMappingTarget)?
     ('sources' ':' 
         INDENT 
             (LIST_ITEM sources+=AttributeMappingSource)+     

--- a/extensions/crossmodel-lang/src/language-server/grammar/relationship.langium
+++ b/extensions/crossmodel-lang/src/language-server/grammar/relationship.langium
@@ -4,10 +4,10 @@ import 'entity'
 
 // Relationship definition
 interface Relationship extends DataElementContainerLink, WithCustomProperties {
-    parent: @LogicalEntity
+    parent?: @LogicalEntity
     parentRole?: string
     parentCardinality?: string
-    child: @LogicalEntity
+    child?: @LogicalEntity
     childRole?: string
     childCardinality?: string
     attributes: RelationshipAttribute[]
@@ -19,10 +19,10 @@ Relationship returns Relationship:
     'relationship' ':' 
         INDENT
             NamedObjectFragment
-            'parent' ':' parent=[LogicalEntity:IDReference]
+            ('parent' ':' parent=[LogicalEntity:IDReference])?
             ('parentRole' ':' parentRole=STRING)?
             ('parentCardinality' ':' parentCardinality=Cardinality)?
-            'child' ':' child=[LogicalEntity:IDReference]
+            ('child' ':' child=[LogicalEntity:IDReference])?
             ('childRole' ':' childRole=STRING)?
             ('childCardinality' ':' childCardinality=Cardinality)?
             ('attributes' ':'
@@ -35,12 +35,12 @@ Relationship returns Relationship:
 ;
 
 interface RelationshipAttribute extends WithCustomProperties {
-    parent: @LogicalAttribute
-    child: @LogicalAttribute
+    parent?: @LogicalAttribute
+    child?: @LogicalAttribute
 }
 
 RelationshipAttribute returns RelationshipAttribute:
-    'parent' ':' parent=[LogicalAttribute:IDReference]
-    'child' ':' child=[LogicalAttribute:IDReference]
+    'parent' ':' (parent=[LogicalAttribute:IDReference])?
+    'child' ':' (child=[LogicalAttribute:IDReference])?
     CustomPropertiesFragment?
 ;

--- a/extensions/crossmodel-lang/test/language-server/cross-model-lang-entity.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-lang-entity.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, expect, test } from '@jest/globals';
 
-import { entity1, entity2, entity3, entity4 } from './test-utils/test-documents/entity/index.js';
+import { entity1, entity2, entity3, entity4, entityWithCustomProperties } from './test-utils/test-documents/entity/index.js';
 import { createCrossModelTestServices, parseLogicalEntity } from './test-utils/utils.js';
 
 const services = createCrossModelTestServices();
@@ -17,6 +17,15 @@ describe('CrossModel language Entity', () => {
          expect(entity.name).toBe('Customer');
          expect(entity.description).toBe('A customer with whom a transaction has been made.');
       });
+
+      test('With custom properties', async () => {
+         const entity = await parseLogicalEntity({ services, text: entityWithCustomProperties });
+         expect(entity.id).toBe('Customer');
+         expect(entity.name).toBe('Customer');
+         expect(entity.customProperties[0].id).toBe('customProperty1');
+         expect(entity.customProperties[0].name).toBe('Custom Property 1');
+         expect(entity.customProperties[0].value).toBe('Value 1');
+      });
    });
 
    describe('With attributes', () => {
@@ -26,6 +35,10 @@ describe('CrossModel language Entity', () => {
          expect(entity.attributes[0].id).toBe('Id');
          expect(entity.attributes[0].name).toBe('Id');
          expect(entity.attributes[0].datatype).toBe('Integer');
+      });
+
+      test('entity with indentation error', async () => {
+         await parseLogicalEntity({ services, text: entity3 }, { parserErrors: 1 });
       });
 
       test('entity with attributes coming before the description and name', async () => {
@@ -38,10 +51,6 @@ describe('CrossModel language Entity', () => {
          expect(entity.attributes[0].id).toBe('Id');
          expect(entity.attributes[0].name).toBe('Id');
          expect(entity.attributes[0].datatype).toBe('Integer');
-      });
-
-      test('entity with indentation error', async () => {
-         await parseLogicalEntity({ services, text: entity3 }, { parserErrors: 1 });
       });
    });
 });

--- a/extensions/crossmodel-lang/test/language-server/cross-model-lang-entity.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-lang-entity.test.ts
@@ -29,7 +29,7 @@ describe('CrossModel language Entity', () => {
       });
 
       test('entity with attributes coming before the description and name', async () => {
-         const entity = await parseLogicalEntity({ services, text: entity4 }, { parserErrors: 3 });
+         const entity = await parseLogicalEntity({ services, text: entity4 }, { parserErrors: 2 });
          expect(entity.id).toBe('Customer');
          expect(entity.name).toBeUndefined();
          expect(entity.description).toBeUndefined();

--- a/extensions/crossmodel-lang/test/language-server/cross-model-lang-relationship.test.ts
+++ b/extensions/crossmodel-lang/test/language-server/cross-model-lang-relationship.test.ts
@@ -39,12 +39,12 @@ describe('CrossModel language Relationship', () => {
 
       expect(isReference(relationship.parent)).toBe(true);
       expect(isReference(relationship.child)).toBe(true);
-      expect(relationship.parent.$refText).toBe('Customer');
-      expect(relationship.child.$refText).toBe('Order');
+      expect(relationship.parent?.$refText).toBe('Customer');
+      expect(relationship.child?.$refText).toBe('Order');
    });
 
    test('relationship with indentation error', async () => {
-      await parseRelationship({ services, text: relationship2 }, { parserErrors: 2 });
+      await parseRelationship({ services, text: relationship2 }, { parserErrors: 1 });
    });
 
    test('relationship with attributes', async () => {

--- a/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/entity/entity-with-custom-properties.ts
+++ b/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/entity/entity-with-custom-properties.ts
@@ -1,0 +1,10 @@
+/********************************************************************************
+ * Copyright (c) 2023 CrossBreeze.
+ ********************************************************************************/
+export const entityWithCustomProperties = `entity: 
+    id: Customer
+    name: 'Customer'
+    customProperties:
+      - id: customProperty1
+        name: 'Custom Property 1'
+        value: 'Value 1'`;

--- a/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/entity/index.ts
+++ b/extensions/crossmodel-lang/test/language-server/test-utils/test-documents/entity/index.ts
@@ -3,6 +3,7 @@
  ********************************************************************************/
 export * from './address.js';
 export * from './customer.js';
+export * from './entity-with-custom-properties.js';
 export * from './entity1.js';
 export * from './entity2.js';
 export * from './entity3.js';

--- a/packages/model-service/src/browser/model-service-frontend-module.ts
+++ b/packages/model-service/src/browser/model-service-frontend-module.ts
@@ -2,7 +2,7 @@
  * Copyright (c) 2023 CrossBreeze.
  ********************************************************************************/
 
-import { WebSocketConnectionProvider } from '@theia/core/lib/browser';
+import { RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { MODEL_SERVICE_PATH, ModelService, ModelServiceClient, ModelServiceServer } from '../common/model-service-rpc';
 import { ModelServiceImpl } from './model-service';
@@ -14,7 +14,7 @@ export default new ContainerModule(bind => {
    bind(ModelServiceServer)
       .toDynamicValue(ctx => {
          // establish the proxy-based connection to the Theia backend service with our client implementation
-         const connection = ctx.container.get(WebSocketConnectionProvider);
+         const connection: ServiceConnectionProvider = ctx.container.get(RemoteConnectionProvider);
          const backendClient: ModelServiceClient = ctx.container.get(ModelServiceClient);
          return connection.createProxy<ModelServiceServer>(MODEL_SERVICE_PATH, backendClient);
       })

--- a/packages/protocol/src/model-service/protocol.ts
+++ b/packages/protocol/src/model-service/protocol.ts
@@ -22,7 +22,7 @@ export interface CrossModelElement {
 }
 
 export interface IdentifiedObject {
-   id?: string;
+   id: string;
    $globalId: string;
 }
 

--- a/packages/protocol/src/model-service/protocol.ts
+++ b/packages/protocol/src/model-service/protocol.ts
@@ -21,17 +21,21 @@ export interface CrossModelElement {
    readonly $type: string;
 }
 
-export interface Identifiable {
-   id: string;
+export interface IdentifiedObject {
+   id?: string;
    $globalId: string;
+}
+
+export interface NamedObject extends IdentifiedObject {
+   name?: string;
+   description?: string;
 }
 
 export interface WithCustomProperties {
    customProperties?: Array<CustomProperty>;
 }
 
-export interface CustomProperty {
-   name: string;
+export interface CustomProperty extends NamedObject {
    value?: string;
 }
 
@@ -57,35 +61,36 @@ export function isCrossModelRoot(model?: any): model is CrossModelRoot {
 }
 
 export const LogicalEntityType = 'LogicalEntity';
-export interface LogicalEntity extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface LogicalEntity extends CrossModelElement, NamedObject, WithCustomProperties {
    readonly $type: typeof LogicalEntityType;
    attributes: Array<LogicalAttribute>;
-   description?: string;
-   name?: string;
+   identifiers: Array<LogicalIdentifier>;
 }
 
-export interface Attribute extends CrossModelElement, Identifiable {
+export const LogicalIdentifierType = 'LogicalIdentifier';
+export interface LogicalIdentifier extends CrossModelElement, NamedObject, WithCustomProperties {
+   primary?: boolean;
+   attributes: Array<LogicalAttribute>;
+}
+
+export interface AbstractLogicalAttribute extends CrossModelElement, NamedObject {
    datatype?: string;
-   description?: string;
-   name?: string;
-}
-
-export const LogicalAttributeType = 'LogicalAttribute';
-export interface LogicalAttribute extends Attribute, WithCustomProperties {
-   readonly $type: typeof LogicalAttributeType;
    identifier?: boolean;
 }
 
+export const LogicalAttributeType = 'LogicalAttribute';
+export interface LogicalAttribute extends CrossModelElement, AbstractLogicalAttribute {
+   readonly $type: typeof LogicalAttributeType;
+}
+
 export const RelationshipType = 'Relationship';
-export interface Relationship extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface Relationship extends CrossModelElement, NamedObject, WithCustomProperties {
    readonly $type: typeof RelationshipType;
-   name?: string;
    attributes: Array<RelationshipAttribute>;
    parent?: Reference<LogicalEntity>;
    parentCardinality?: string;
    child?: Reference<LogicalEntity>;
    childCardinality?: string;
-   description?: string;
 }
 
 export const RelationshipAttributeType = 'RelationshipAttribute';
@@ -96,7 +101,7 @@ export interface RelationshipAttribute extends CrossModelElement, WithCustomProp
 }
 
 export const MappingType = 'Mapping';
-export interface Mapping extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface Mapping extends CrossModelElement, IdentifiedObject, WithCustomProperties {
    readonly $type: typeof MappingType;
    sources: Array<SourceObject>;
    target: TargetObject;
@@ -104,7 +109,7 @@ export interface Mapping extends CrossModelElement, Identifiable, WithCustomProp
 
 export const SourceObjectType = 'SourceObject';
 export type SourceObjectJoinType = 'from' | 'inner-join' | 'cross-join' | 'left-join' | 'apply';
-export interface SourceObject extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface SourceObject extends CrossModelElement, IdentifiedObject, WithCustomProperties {
    readonly $type: typeof SourceObjectType;
    entity?: Reference<LogicalEntity>;
    join?: SourceObjectJoinType;
@@ -172,33 +177,30 @@ export interface AttributeMapping extends CrossModelElement, WithCustomPropertie
 export const AttributeMappingTargetType = 'AttributeMappingTarget';
 export interface AttributeMappingTarget extends CrossModelElement {
    readonly $type: typeof AttributeMappingTargetType;
-   value?: Reference<Attribute>;
+   value?: Reference<AbstractLogicalAttribute>;
 }
 
 export const TargetObjectAttributeType = 'TargetObjectAttribute';
-export interface TargetObjectAttribute extends Attribute, WithCustomProperties {
+export interface TargetObjectAttribute extends AbstractLogicalAttribute, WithCustomProperties {
    readonly $type: typeof TargetObjectAttributeType;
 }
 
 export const AttributeMappingSourceType = 'AttributeMappingSource';
 export interface AttributeMappingSource extends CrossModelElement {
    readonly $type: typeof AttributeMappingSourceType;
-   value: Reference<Attribute>;
+   value: Reference<AbstractLogicalAttribute>;
 }
 
 export const SourceObjectAttributeType = 'SourceObjectAttribute';
-export interface SourceObjectAttribute extends Attribute, WithCustomProperties {
+export interface SourceObjectAttribute extends AbstractLogicalAttribute, WithCustomProperties {
    readonly $type: typeof SourceObjectAttributeType;
 }
 
 export const SystemDiagramType = 'SystemDiagram';
-export interface SystemDiagram extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface SystemDiagram extends CrossModelElement, IdentifiedObject, WithCustomProperties {
    readonly $container: CrossModelRoot;
    readonly $type: typeof SystemDiagramType;
-   customProperties: Array<CustomProperty>;
-   description?: string;
    edges: Array<Edge>;
-   name?: string;
    nodes: Array<EntityNode>;
 }
 
@@ -206,30 +208,26 @@ export type Edge = InheritanceEdge | RelationshipEdge;
 export const EdgeType = 'Edge';
 
 export const InheritanceEdgeType = 'InheritanceEdge';
-export interface InheritanceEdge extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface InheritanceEdge extends CrossModelElement, IdentifiedObject, WithCustomProperties {
    readonly $container: SystemDiagram;
    readonly $type: typeof InheritanceEdgeType;
    baseNode: Reference<EntityNode>;
-   customProperties: Array<CustomProperty>;
    superNode: Reference<EntityNode>;
 }
 
 export const RelationshipEdgeType = 'RelationshipEdge';
-export interface RelationshipEdge extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface RelationshipEdge extends CrossModelElement, IdentifiedObject, WithCustomProperties {
    readonly $container: SystemDiagram;
    readonly $type: typeof RelationshipEdgeType;
-   customProperties: Array<CustomProperty>;
    relationship: Reference<Relationship>;
    sourceNode: Reference<EntityNode>;
    targetNode: Reference<EntityNode>;
 }
 
 export const EntityNodeType = 'EntityNode';
-export interface EntityNode extends CrossModelElement, Identifiable, WithCustomProperties {
+export interface EntityNode extends CrossModelElement, IdentifiedObject, WithCustomProperties {
    readonly $container: SystemDiagram;
    readonly $type: typeof EntityNodeType;
-   customProperties: Array<CustomProperty>;
-   description?: string;
    entity: Reference<LogicalEntity>;
    height: number;
    name?: string;

--- a/packages/protocol/src/model-service/protocol.ts
+++ b/packages/protocol/src/model-service/protocol.ts
@@ -269,12 +269,20 @@ export namespace ModelDiagnostic {
       return diagnostic.severity === 'error';
    }
 
+   export function isParseError(diagnostic: ModelDiagnostic): boolean {
+      return diagnostic.type === 'parsing-error';
+   }
+
    export function errors(diagnostics: ModelDiagnostic[]): ModelDiagnostic[] {
       return diagnostics.filter(isError);
    }
 
    export function hasErrors(diagnostics: ModelDiagnostic[]): boolean {
       return diagnostics.some(isError);
+   }
+
+   export function hasParseErrors(diagnostics: ModelDiagnostic[]): boolean {
+      return diagnostics.some(isParseError);
    }
 }
 

--- a/packages/react-model-ui/src/ModelContext.tsx
+++ b/packages/react-model-ui/src/ModelContext.tsx
@@ -69,7 +69,7 @@ export function useDirty(): boolean {
 }
 
 export function useReadonly(): boolean {
-   return ModelDiagnostic.hasErrors(useDiagnostics());
+   return ModelDiagnostic.hasParseErrors(useDiagnostics());
 }
 
 export function useEntity(): LogicalEntity {

--- a/packages/react-model-ui/src/views/form/Header.tsx
+++ b/packages/react-model-ui/src/views/form/Header.tsx
@@ -23,7 +23,7 @@ export function Header({ name, id, iconClass }: HeaderProps): React.ReactElement
 
    return (
       <AppBar position='sticky'>
-         {ModelDiagnostic.hasErrors(diagnostics) && createEditorError(ERRONEOUS_MODEL)}
+         {ModelDiagnostic.hasParseErrors(diagnostics) && createEditorError(ERRONEOUS_MODEL)}
          <Toolbar variant='dense' sx={{ minHeight: '40px' }}>
             <Box sx={{ display: { xs: 'none', sm: 'flex' }, flexGrow: 1, gap: '1em', alignItems: 'center' }}>
                {iconClass && <Icon baseClassName='codicon' className={iconClass} sx={{ fontSize: '1.7em !important' }} />}


### PR DESCRIPTION
As preparation for using the forms for creating new objects:
- Refactored grammar to be less restrictive (allow empty id's and made all properties optional).
- Added id property to customProperties and refactored implementation and examples accordingly.
- Refactored ErrorView and disabled properties on forms to only activate on parse errors.
- Refactored validations to rely on IdentifiedObject supertype i.s.o. generic AstNode parent.
- Refactored unique id validation to validate semantic root objects globally and all other IdentifiedObject types locally (within collection).
- Resolved lint warning on deprecated WebSocketConnectionProvider usage.