### PR TITLE
fix: Ensure no error is thrown if there are no sources in a mapping

### DIFF
--- a/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
+++ b/extensions/crossmodel-lang/src/language-server/cross-model-validator.ts
@@ -179,7 +179,7 @@ export class CrossModelValidator {
       this.markDuplicateIds(node.customProperties, accept);
    }
 
-   protected markDuplicateIds(nodes: IdentifiableAstNode[], accept: ValidationAcceptor): void {
+   protected markDuplicateIds(nodes: IdentifiableAstNode[] = [], accept: ValidationAcceptor): void {
       const knownIds: string[] = [];
       for (const node of nodes) {
          if (node.id && knownIds.includes(node.id)) {


### PR DESCRIPTION
Fixes #143